### PR TITLE
Make global variable `const` in Julia

### DIFF
--- a/src/leibniz.jl
+++ b/src/leibniz.jl
@@ -10,5 +10,5 @@ function f(rounds)
     return pi*4
 end
 
-rounds = parse(Int64, readchomp(joinpath(@__DIR__, "rounds.txt")))
+const rounds = parse(Int64, readchomp(joinpath(@__DIR__, "rounds.txt")))
 print(f(rounds))


### PR DESCRIPTION
This makes the first run of the `f` function in Julia less awful.  Before the PR (same as https://github.com/niklas-heer/speed-comparison/pull/13#issuecomment-1264752392):
```julia
julia> @time f(rounds) # first run, it includes compilation
  0.013784 seconds (31.09 k allocations: 1.708 MiB, 72.31% compilation time)
3.1415916535917745

julia> @time f(rounds) # second run, it doesn't include compilation
  0.004539 seconds (1 allocation: 16 bytes)
3.1415916535917745
```
With this PR:
```julia
julia> @time f(rounds) # first run
  0.003867 seconds
3.1415916535917745

julia> @time f(rounds) # second run
  0.003896 seconds
3.1415916535917745
```

For the record:
```julia
julia> versioninfo()
Julia Version 1.8.1
Commit afb6c60d69a (2022-09-06 15:09 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 8 × Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, haswell)
  Threads: 1 on 8 virtual cores
```