### PR TITLE
Add Clojure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.clj-kondo
+.lsp
 .vscode
 .idea
 results/*.csv

--- a/Earthfile
+++ b/Earthfile
@@ -26,6 +26,7 @@ collect-data:
 
   # Work through programming languages
   BUILD +c
+  BUILD +clojure
   BUILD +cpp
   BUILD +crystal
   BUILD +elixir
@@ -55,6 +56,18 @@ c:
   RUN --no-cache gcc leibniz.c -o leibniz -O3 -s -static -flto -march=native -mtune=native -fomit-frame-pointer
   RUN --no-cache ./scbench "./leibniz" -i $iterations -l "gcc --version" --export json --lang "C (gcc)"
   SAVE ARTIFACT ./scbench-summary.json AS LOCAL ./results/c.json
+
+clojure:
+  FROM clojure:temurin-19-tools-deps-alpine
+  COPY ./src/rounds.txt ./
+  COPY +build/scbench ./
+
+  # Seems to be a bug
+  RUN apk add --no-cache rlwrap
+
+  COPY ./src/leibniz.clj ./
+  RUN --no-cache ./scbench "clj leibniz.clj" -i $iterations -l "clj --version" --export json --lang "Clojure"
+  SAVE ARTIFACT ./scbench-summary.json AS LOCAL ./results/clojure.json
 
 cpp:
   FROM +alpine

--- a/Earthfile
+++ b/Earthfile
@@ -26,7 +26,8 @@ collect-data:
 
   # Work through programming languages
   BUILD +c
-  BUILD +clojure
+  BUILD +clj
+  BUILD +clj-bb
   BUILD +cpp
   BUILD +crystal
   BUILD +elixir
@@ -57,7 +58,7 @@ c:
   RUN --no-cache ./scbench "./leibniz" -i $iterations -l "gcc --version" --export json --lang "C (gcc)"
   SAVE ARTIFACT ./scbench-summary.json AS LOCAL ./results/c.json
 
-clojure:
+clj:
   FROM clojure:temurin-19-tools-deps-alpine
   COPY ./src/rounds.txt ./
   COPY +build/scbench ./
@@ -67,7 +68,17 @@ clojure:
 
   COPY ./src/leibniz.clj ./
   RUN --no-cache ./scbench "clj leibniz.clj" -i $iterations -l "clj --version" --export json --lang "Clojure"
-  SAVE ARTIFACT ./scbench-summary.json AS LOCAL ./results/clojure.json
+  SAVE ARTIFACT ./scbench-summary.json AS LOCAL ./results/clj.json
+
+clj-bb:
+  # Uses https://babashka.org/
+  FROM babashka/babashka:alpine
+  COPY ./src/rounds.txt ./
+  COPY +build/scbench ./
+
+  COPY ./src/leibniz.clj ./
+  RUN --no-cache ./scbench "bb -f leibniz.clj" -i $iterations -l "bb --version" --export json --lang "Clojure (Babashka)"
+  SAVE ARTIFACT ./scbench-summary.json AS LOCAL ./results/clj-bb.json
 
 cpp:
   FROM +alpine

--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@
 # Speed comparison of programming languages
 
 This projects tries to compare the speed of different programming languages.
-In this project we don't really care about getting a precise calculation of pi. We only want to see how fast are the programming languages doing.
+In this project we don't really care about getting a precise calculation of pi. We only want to see how fast are the programming languages doing. <br />
+It uses an implementation of the [Leibniz formula for π](https://en.wikipedia.org/wiki/Leibniz_formula_for_%CF%80) to do the comparison. <br />
+Here is a video which explains how it works: [Calculating π by hand](https://www.youtube.com/watch?v=HrRMnzANHHs)
 
 You can find the results here: https://niklas-heer.github.io/speed-comparison/
-
-It uses an implementation of the [Leibniz formula for π](https://en.wikipedia.org/wiki/Leibniz_formula_for_%CF%80) to do the comparison.
-
-Here is a video which explains how it works: [Calculating π by hand](https://www.youtube.com/watch?v=HrRMnzANHHs)
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -20,22 +20,23 @@ You are also welcome to contribute and help me fix my possible horrible code in 
 
 ## Languages used in this comparison
 
-- [C](https://en.wikipedia.org/wiki/C_(programming_language)) - compiled
-- [C++](https://isocpp.org/) - compiled
-- [Crystal](https://crystal-lang.org/) - compiled
-- [Elixir](https://elixir-lang.org/) - compiled
-- [Go](https://golang.org/) - compiled
-- [Java](http://www.oracle.com/technetwork/java/index.html) - compiled, VM
-- [Julia](http://julialang.org/) - JIT
-- [Javascript](https://www.ecma-international.org/publications/standards/Ecma-402.htm) using [Node.js](https://nodejs.org/) - interpreted, JIT
-- [Lua](https://www.lua.org/) - interpreted
-- [Nim](https://nim-lang.org/) - compiled
-- [PHP](https://secure.php.net/) - interpreted
-- [Python](https://www.python.org/) - interpreted (CPython)
-- [R](https://www.r-project.org/) - interpreted
-- [Ruby](https://www.ruby-lang.org/) - interpreted
-- [Rust](https://www.rust-lang.org/)  - compiled
-- [Swift](https://swift.org/) - compiled (in this test interpreted due to Linux Swift limitations)
+- [C](https://en.wikipedia.org/wiki/C_(programming_language))
+- [Clojure](https://en.wikipedia.org/wiki/Clojure)
+- [C++](hhttps://en.wikipedia.org/wiki/C%2B%2B)
+- [Crystal](https://en.wikipedia.org/wiki/Crystal_(programming_language))
+- [Elixir](https://en.wikipedia.org/wiki/Elixir_(programming_language))
+- [Go](https://en.wikipedia.org/wiki/Go_(programming_language))
+- [Java](https://en.wikipedia.org/wiki/Java_(programming_language))
+- [Julia](https://en.wikipedia.org/wiki/Julia_(programming_language))
+- [Javascript](https://en.wikipedia.org/wiki/JavaScript) using [Node.js](https://en.wikipedia.org/wiki/Node.js)
+- [Lua](https://en.wikipedia.org/wiki/Lua_(programming_language))
+- [Nim](https://en.wikipedia.org/wiki/Nim_(programming_language))
+- [PHP](https://en.wikipedia.org/wiki/PHP)
+- [Python](https://en.wikipedia.org/wiki/Python_(programming_language))
+- [R](https://en.wikipedia.org/wiki/R_(programming_language))
+- [Ruby](https://en.wikipedia.org/wiki/Ruby_(programming_language))
+- [Rust](https://en.wikipedia.org/wiki/Rust_(programming_language))
+- [Swift](https://en.wikipedia.org/wiki/Swift_(programming_language))
 
 ## Run it yourself
 

--- a/src/leibniz.clj
+++ b/src/leibniz.clj
@@ -1,0 +1,12 @@
+(ns leibniz)
+
+;; https://codereview.stackexchange.com/a/19942
+(defn calc-pi-leibniz [terms]
+  (* 4 (- (reduce + (map / (range 1.0 terms 4.0)))
+          (reduce + (map / (range 3.0 terms 4.0))))))
+
+(defn parse-int [s]
+  (Integer/parseInt (re-find #"\A-?\d+" s)))
+
+(def rounds (parse-int (slurp "rounds.txt")))
+(println (calc-pi-leibniz rounds))


### PR DESCRIPTION
This adds Clojure as a language.

We have two executions, one time by the standard `clj` command and the other by [Babashka](https://babashka.org/), which is a fast native Clojure interpreter.