### PR TITLE
Nim has compilation flags equivalent to "-O3" for c/c++

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -167,7 +167,7 @@ nim:
   RUN apk add --no-cache gcc build-base nim
 
   COPY ./src/leibniz.nim ./
-  RUN --no-cache nim c --verbosity:0 leibniz.nim
+  RUN --no-cache nim c --verbosity:0 -d:danger --passC:"-flto"  --passL:"-flto" --gc:arc --out:leibniz leibniz.nim
   RUN --no-cache ./scbench "./leibniz" -i $iterations -l "nim --version" --export json --lang "Nim"
   SAVE ARTIFACT ./scbench-summary.json AS LOCAL ./results/nim.json
 


### PR DESCRIPTION
Hello!
I think that Nim with these flags can reach c/c++ performance range :)
there is also "-d:release", but omitting those is the equivalent of a debug build.