### PR TITLE
Tightening the screw for R

### DIFF
--- a/src/leibniz.r
+++ b/src/leibniz.r
@@ -1,6 +1,6 @@
 fileName <- "rounds.txt"
 rounds <- as.integer(readChar(fileName, file.info(fileName)$size))
   
-pi <- 4*(1+sum(c(-1,1)/((seq.int(4, 2*rounds+2, 2)-1))))
+pi <- 4*sum(1 / seq.int(-2*rounds+1, 2*rounds, by = 4))
 
 cat(sprintf("%.16f\n", pi))


### PR DESCRIPTION
Optimised by avoiding some operations and creating the sequence in a simpler way.

Note: for the curious, this _is_ still producing the Leibniz sequence of the correct size...
```
rounds <- 10
x <- 1 / seq.int(-2*rounds+1, 2*rounds, by = 4)
length(x) == rounds
#> [1] TRUE
x[rev(order(abs(x)))]
#>  [1]  1.00000000 -0.33333333  0.20000000 -0.14285714  0.11111111 -0.09090909
#>  [7]  0.07692308 -0.06666667  0.05882353 -0.05263158
```

Credit to @HenrikBengtsson via [Twitter](https://twitter.com/henrikbengtsson/status/1582049787616309248?s=20&t=IOUWfKKvQ6qZllZPSHQCug).