### PR TITLE
Use a lazy vector for Julia

### DIFF
--- a/src/leibniz.jl
+++ b/src/leibniz.jl
@@ -1,9 +1,15 @@
+struct SignVector <: AbstractVector{Float64}
+    len::Int
+end
+Base.size(s::SignVector) = (s.len,)
+Base.getindex(::SignVector, i::Int) = Float64((-1)^iseven(i))
+
 function f(rounds)
-    x = 1.0
+    xs = SignVector(rounds + 2)
     pi = 1.0
 
-    for i in 2:(rounds + 2)
-        x *= -1
+    @simd for i in 2:(rounds + 2)
+        x = xs[i]
         pi += x / (2 * i - 1)
     end
 


### PR DESCRIPTION
If I understand right, #45 changed the R implementation to store a vector for `x`, and access this at each iteration. Which is idiomatic R, instead of a loop.

This does something similar for Julia, making a lazy vector for the `x` values, and accessing this within the loop. Julia has many such lazy array types, in fact the loop already reads `i` from a `UnitRange`, which is what `:` creates:
```
julia> 2:(range + 2) isa AbstractVector
true

julia> 2:(range + 2) |> dump
UnitRange{Int64}
  start: Int64 2
  stop: Int64 1000002

julia> SignVector(range + 2) isa AbstractVector
true

julia> SignVector(3)
3-element SignVector:
  1.0
 -1.0
  1.0
```
The [`@simd` macro](https://docs.julialang.org/en/v1/base/base/#Base.SimdLoop.@simd) is also fairly standard on tight inner loops. Often the compiler can infer that the loop is safe, but for this particular function it does not, in local testing. The new one is both faster and very slightly more accurate, due to floating point differences:
```
julia> using BenchmarkTools

julia> @btime f_prev(10^6) - pi
  1.552 ms (0 allocations: 0 bytes)
-9.999980186137236e-7

julia> @btime f(10^6) - pi
  531.375 μs (0 allocations: 0 bytes)
-9.999979067032427e-7
```