### PR TITLE
accuracy seems not to represent the truth

### DIFF
--- a/scbench/cmd/scbench/main.go
+++ b/scbench/cmd/scbench/main.go
@@ -71,14 +71,16 @@ func hammingDistancePct(base string, other string) (float64, error) {
 		return 0, errors.New("strings do not have the same length")
 	}
 
-	var correct int = 0
+	var correct float64 = 0.0;
+	var weight float64 = 0.0;
 	for i := range rbase {
 		if rother[i] == rbase[i] {
-				correct++
+			correct+=1.0/float64(i+1)
 		}
+		weight+=1.0/float64(i+1)
 	}
 
-	return float64(correct) / float64(len(base)), nil
+	return correct/weight, nil
 }
 
 // Truncate string.


### PR DESCRIPTION
See https://github.com/niklas-heer/speed-comparison/pull/63#issuecomment-1283574761. perhaps a better metric is to assign more weight to more significant digits. (Or to change it altogether in another PR.)