### PR TITLE
Faster Lua code

### DIFF
--- a/src/leibniz.lua
+++ b/src/leibniz.lua
@@ -1,17 +1,14 @@
-function readAll(file)
-    local f = assert(io.open(file, "rb"))
-    local content = f:read("*all")
-    f:close()
-    return content
-end
+local f = assert(io.open("rounds.txt", "rb"))
+local content = f:read("a")
+f:close()
 
-rounds = tonumber(readAll("rounds.txt"))
+local rounds = tonumber(content)
 
-x = 1.0
-pi = 1.0
+local x = 1
+local pi = 1.0
 
 for i = 2, rounds + 2 do
-    x = x * -1
+    x = -x
     pi = pi + (x / (2 * i - 1))
 end
 


### PR DESCRIPTION
```
Benchmark 1: lua leibniz.lua
  Time (mean ± σ):      6.420 s ±  0.826 s    [User: 6.418 s, System: 0.001 s]
  Range (min … max):    5.244 s …  7.169 s    10 runs

Benchmark 2: lua faster.lua
  Time (mean ± σ):      1.425 s ±  0.018 s    [User: 1.423 s, System: 0.002 s]
  Range (min … max):    1.396 s …  1.461 s    10 runs

Summary
  'lua faster.lua' ran
    4.50 ± 0.58 times faster than 'lua leibniz.lua'
```

```
Benchmark 1: luajit leibniz.lua
  Time (mean ± σ):     150.9 ms ±   3.8 ms    [User: 150.3 ms, System: 0.5 ms]
  Range (min … max):   147.4 ms … 159.6 ms    19 runs

Benchmark 2: luajit faster.lua
  Time (mean ± σ):     119.1 ms ±   3.8 ms    [User: 118.3 ms, System: 0.8 ms]
  Range (min … max):   115.6 ms … 131.3 ms    24 runs

Summary
  'luajit faster.lua' ran
    1.27 ± 0.05 times faster than 'luajit leibniz.lua'
```