### PR TITLE
[C#] Remove unnecessary string#Replace calls

### DIFF
--- a/src/cs/Program.cs
+++ b/src/cs/Program.cs
@@ -9,7 +9,7 @@ try {
     Console.WriteLine($"Couldn't read file:\n {err.Message}");
 }
 
-int rounds = int.Parse(data.Replace("\n", "").Replace("\r", ""));
+int rounds = int.Parse(data);
 
 double pi = 1;
 double x = 1;


### PR DESCRIPTION
`int32.Parse` ignores whitespace, so there is no need to call `string#Replace`.