### PR TITLE
Haskell implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ results/*.png
 results/*.json
 leibniz
 src/cs/obj/Debug
+*.o
+*.hi

--- a/Earthfile
+++ b/Earthfile
@@ -204,10 +204,10 @@ go:
   DO +BENCH --name="go" --lang="Go" --version="go version" --cmd="./leibniz"
 
 haskell:
-  FROM --platform=linux/amd64 haskell:9.4.3-slim
+  FROM haskell:9.4.3-slim
   DO +PREPARE_DEBIAN
   DO +ADD_FILES --src="leibniz.hs"
-  RUN --no-cache ghc -O2 leibniz.hs
+  RUN --no-cache ghc -funfolding-use-threshold=16 -O2 -optc-O3 leibniz.hs
   DO +BENCH --name="haskell" --lang="Haskell (GHC)" --version="ghc --version" --cmd="./leibniz"
 
 java:

--- a/Earthfile
+++ b/Earthfile
@@ -71,6 +71,7 @@ collect-data:
   BUILD +elixir
   BUILD +fortran
   BUILD +go
+  BUILD +haskell
   BUILD +java
   BUILD +julia
   BUILD +julia-compiled
@@ -173,7 +174,7 @@ d:
   RUN apk add --no-cache gcc-gdc
   RUN --no-cache gdc leibniz.d -o leibniz -O3 -frelease -static -flto -ffast-math -march=native -mtune=native -fomit-frame-pointer -fno-signed-zeros -fno-trapping-math -fassociative-math
   DO +BENCH --name="d" --lang="D (GDC)" --version="gdc --version" --cmd="./leibniz"
-  
+
 d-ldc:
   FROM +alpine --src="leibniz.d"
   RUN apk add --no-cache ldc gcc musl-dev llvm-libunwind-static llvm12
@@ -201,6 +202,13 @@ go:
   DO +ADD_FILES --src="leibniz.go"
   RUN --no-cache go build leibniz.go
   DO +BENCH --name="go" --lang="Go" --version="go version" --cmd="./leibniz"
+
+haskell:
+  FROM --platform=linux/amd64 haskell:9.4.3-slim
+  DO +PREPARE_DEBIAN
+  DO +ADD_FILES --src="leibniz.hs"
+  RUN --no-cache ghc -O2 leibniz.hs
+  DO +BENCH --name="haskell" --lang="Haskell (GHC)" --version="ghc --version" --cmd="./leibniz"
 
 java:
   # Using a dedicated image due to the packages on alpine being not up to date.

--- a/src/alt/leibniz_list.hs
+++ b/src/alt/leibniz_list.hs
@@ -1,0 +1,14 @@
+{- | Approach using infinite lists. -}
+module Main where
+
+-- | Computes partial alternating series converging
+--   to π/4=arctan(1) up n terms.
+leibniz :: Int -> Double
+leibniz n = sum . take n $ zipWith (*) (cycle [1, -1]) sequence
+  where sequence = [inv (2*i - 1) | i <- [1..]]
+        inv = recip . fromIntegral
+
+main :: IO ()
+main = rounds >>= putStrLn . show . (4 * ) . leibniz
+  where rounds :: IO Int
+        rounds = read <$> readFile "rounds.txt"

--- a/src/alt/leibniz_right_fold.hs
+++ b/src/alt/leibniz_right_fold.hs
@@ -1,0 +1,22 @@
+{- | A more idiomatic, but slower implementation. -}
+
+module Main where
+
+-- | Computes partial alternating series converging
+--   to π/4=arctan(1) up n terms.
+leibniz :: Int -> Double
+leibniz n = partial 1 where
+  partial k | k > n = 0
+            | otherwise = inv (2*k - 1) - partial (k + 1)
+  inv = recip . fromIntegral
+
+-- Notice:
+--   1 - (1 / 3 - (1/5 - (1/7 - (1/9 - ...))))
+-- = 1 - 1/3 + (1/5 - (1/7 - (1/9 - ...)))
+-- = 1 - 1/3 + 1/5 - 1/7 + (1/9 - ...)
+-- = 1 - 1/3 + 1/5 - 1/7 + 1/9 - ...
+
+main :: IO ()
+main = rounds >>= putStrLn . show . (4 * ) . leibniz
+  where rounds :: IO Int
+        rounds = read <$> readFile "rounds.txt"

--- a/src/leibniz.hs
+++ b/src/leibniz.hs
@@ -1,12 +1,14 @@
+{-# LANGUAGE BangPatterns #-}
+
 {- | A more direct port of the C version. -}
 module Main where
 
 -- | Computes partial alternating series converging
 --   to π/4=arctan(1) up n terms.
 leibniz :: Int -> Double
-leibniz n = partial 2 1.0 where
+leibniz !n = partial 2 1.0 where
   partial :: Int -> Double -> Double
-  partial i qpi
+  partial !i !qpi
     | i == n + 2 = qpi
     | otherwise  = partial (i + 1) $ qpi - powNeg1 i * inv (2*i - 1)
   inv = recip . fromIntegral

--- a/src/leibniz.hs
+++ b/src/leibniz.hs
@@ -1,0 +1,18 @@
+{- | A more direct port of the C version. -}
+module Main where
+
+-- | Computes partial alternating series converging
+--   to π/4=arctan(1) up n terms.
+leibniz :: Int -> Double
+leibniz n = partial 2 1.0 where
+  partial :: Int -> Double -> Double
+  partial i qpi
+    | i == n + 2 = qpi
+    | otherwise  = partial (i + 1) $ qpi - powNeg1 i * inv (2*i - 1)
+  inv = recip . fromIntegral
+  powNeg1 i = 1 - 2 * fromIntegral (i `mod` 2)
+
+main :: IO ()
+main = rounds >>= putStrLn . show . (4 * ) . leibniz
+  where rounds :: IO Int
+        rounds = read <$> readFile "rounds.txt"


### PR DESCRIPTION
This addresses issue #83.

Ported C implementation to Haskell, as well as two alternate more idiomatic implementations. One using lazy infinite lists, and another which is essentially a right fold.

Only the port is included as part of the speed comparison.  I can remove the alternate implementations in `src/alt` if desired.