### PR TITLE
Update leibniz.clj

### DIFF
--- a/src/leibniz.clj
+++ b/src/leibniz.clj
@@ -2,7 +2,7 @@
 
 (defn calc-pi-leibniz 
   "Translation of Java solution to Clojure"
-  [rounds]
+  [^long rounds]
   (let [end (+ 2 rounds)]
     (loop [i 2 x 1.0 pi 1.0]
       (if (= i end)


### PR DESCRIPTION
Avoid reflection (and boxed math) when crunching numbers in Clojure.