### PR TITLE
Add Scala using Scala Native

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -93,6 +93,7 @@ collect-data:
   BUILD +rust
   BUILD +rust-nightly
   BUILD +sbcl
+  BUILD +scala
   BUILD +swift
   BUILD +zig
 
@@ -354,6 +355,16 @@ sbcl:
   RUN apk add --no-cache sbcl
   RUN --no-cache sbcl --noinform --eval '(compile-file "leibniz.lisp")' --quit
   DO +BENCH --name="sbcl" --lang="Common Lisp (SBCL)" --version="sbcl --version" --cmd="sbcl --script leibniz.fasl"
+
+scala:
+  FROM +alpine --src="leibniz.scala"
+  RUN apk add --no-cache clang musl-dev g++
+  RUN wget -q https://github.com/VirtusLab/scala-cli/releases/download/v0.1.19/scala-cli-x86_64-pc-linux-static.gz && \
+      gunzip scala-cli-x86_64-pc-linux-static.gz && \
+      chmod +x scala-cli-x86_64-pc-linux-static && \
+      mv scala-cli-x86_64-pc-linux-static /usr/local/bin/scala-cli
+  RUN scala-cli package leibniz.scala -o leibniz --scala 3.2.1 --native-version 0.4.9 --native --native-mode release-full
+  DO +BENCH --name="scala" --lang="Scala" --version="echo 3.2.1" --cmd="./leibniz"
 
 swift:
   FROM swift:5.7-jammy

--- a/src/leibniz.scala
+++ b/src/leibniz.scala
@@ -1,0 +1,14 @@
+@main
+def main =
+  val rounds = scala.io.Source.fromFile("rounds.txt").getLines.next.trim.toInt
+  var pi = 1.0
+
+  var i = 2
+  while(i < rounds + 2) {
+    val x = -1.0 + 2.0 * (i & 1)
+    pi += (x / (2 * i - 1))
+    i += 1
+  }
+  pi *= 4.0
+
+  println(pi)


### PR DESCRIPTION
This adds a Scala benchmark using the AOT compiler for [Scala](https://www.scala-lang.org), [Scala Native](https://scala-native.org).
To build the code it uses [scala-cli](https://scala-cli.virtuslab.org) which is what people use these days to build small Scala programs.