### PR TITLE
Added a version that uses java vector ops

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -74,6 +74,7 @@ collect-data:
   BUILD +go
   BUILD +haskell
   BUILD +java
+  BUILD +java-vecops
   BUILD +julia
   BUILD +julia-compiled
   BUILD +julia-ux4
@@ -231,6 +232,20 @@ java:
   # OpenJDK Runtime Environment Temurin-19+36 (build 19+36)
   # OpenJDK 64-Bit Server VM Temurin-19+36 (build 19+36, mixed mode, sharing)
   DO +BENCH --name="java" --lang="Java" --version="echo 19.36" --cmd="java leibniz"
+
+
+java-vecops:
+  # Using a dedicated image due to the packages on alpine being not up to date.
+  FROM eclipse-temurin:19_36-jdk-alpine
+  DO +PREPARE_ALPINE
+  DO +ADD_FILES --src="leibnizVecOps.java"
+  RUN --no-cache javac --add-modules jdk.incubator.vector leibnizVecOps.java
+  # TODO: Change scbench to be able to handle Java version. For now it's static.
+  # $ java -version
+  # openjdk version "19" 2022-09-20
+  # OpenJDK Runtime Environment Temurin-19+36 (build 19+36)
+  # OpenJDK 64-Bit Server VM Temurin-19+36 (build 19+36, mixed mode, sharing)
+  DO +BENCH --name="java-vecops" --lang="Java (Vec Ops)" --version="echo 19.36" --cmd="java --add-modules jdk.incubator.vector leibnizVecOps"
 
 julia:
   # We have to use a special image since there is no Julia package on alpine 🤷‍♂️

--- a/src/leibniz.clj
+++ b/src/leibniz.clj
@@ -1,6 +1,8 @@
 (ns leibniz)
 
-(defn calc-pi-leibniz 
+(set! *unchecked-math* :warn-on-boxed)
+
+(defn calc-pi-leibniz
   "Translation of Java solution to Clojure"
   [^long rounds]
   (let [end (+ 2 rounds)]

--- a/src/leibnizVecOps.java
+++ b/src/leibnizVecOps.java
@@ -1,0 +1,55 @@
+import java.nio.charset.Charset;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
+import jdk.incubator.vector.DoubleVector;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorShuffle;
+
+
+
+public class leibnizVecOps {
+  static String readFile(String path, Charset encoding) throws IOException {
+    byte[] encoded = Files.readAllBytes(Paths.get(path));
+    return new String(encoded, encoding);
+  }
+
+  public static void main(String[] args) {
+    String data = "";
+
+    try {
+      data = readFile("rounds.txt", StandardCharsets.UTF_8);
+    } catch (IOException err) {
+      System.out.println("Couldn't read file:\n" + err.getMessage());
+    }
+
+    int rounds = Integer.parseInt(data.replace("\n", "").replace("\r", ""));
+
+    final VectorSpecies<Double> species = DoubleVector.SPECIES_PREFERRED;
+    final int vecLen = species.length();
+    final int nVecGroups = rounds / vecLen;
+
+    final DoubleVector divConstants = DoubleVector.fromArray(species, new double[]{1.0, 3.0, 5.0, 7.0, 9.0, 11.0, 13.0, 15.0},0);
+    final DoubleVector aones = DoubleVector.fromArray(species, new double[]{1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0},0);
+    final DoubleVector ones = DoubleVector.broadcast(species, 1.0);
+    DoubleVector sumTarget = DoubleVector.broadcast(species, 0.0);
+    final int dvecLen = vecLen*2;
+
+
+    for(int vidx = 0; vidx < nVecGroups; ++vidx) {
+      sumTarget = sumTarget.add(ones.div(divConstants.add(dvecLen*vidx).mul(aones)));
+    }
+
+    double pi = sumTarget.reduceLanes(VectorOperators.ADD);
+    for(int idx = nVecGroups * vecLen; idx < rounds; ++idx) {
+      final double x = 1.0 - (2.0 * (idx & 0x1));
+      pi += (x / (1 + (2*idx)));
+    }
+
+    pi *= 4;
+    System.out.println(pi);
+  }
+}


### PR DESCRIPTION
This version uses JDK-19 vector ops.  Without any in-process warmup, it is slower than the original java version by quite a lot.  I wonder if hyperfine could be modified to use nailgun or some similar system to allow the actual java JIT time to warmup.

Given a sufficient in-process warmup, it is a bit over twice as fast as the java version - https://github.com/cnuernber/leibniz.

It seems any JIT language is going to have this disadvantage honestly in this type of benchmark as they are only partially compiled at best.

In any case, our community (clojure) had a great time with this benchmark and we found some legitimate issues with our compiler. 

Included in this PR is a small change that makes the Clojure version a bit faster.
