### PR TITLE
Add OCaml

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -83,6 +83,7 @@ collect-data:
   BUILD +lua
   BUILD +luajit
   BUILD +nim
+  BUILD +ocaml
   BUILD +php
   BUILD +perl
   BUILD +pony
@@ -302,6 +303,12 @@ nim:
   RUN apk add --no-cache gcc build-base nim
   RUN --no-cache nim c --verbosity:0 -d:danger -d:lto --gc:arc --passC:"-march=native -fno-signed-zeros -fno-trapping-math -fassociative-math" --passL:"-s" leibniz.nim
   DO +BENCH --name="nim" --lang="Nim" --version="nim --version" --cmd="./leibniz"
+
+ocaml:
+  FROM +alpine --src="leibniz.ml"
+  DO apk add --no-cache ocaml
+  RUN --no-cache ocamlopt -O2 -o leibniz leibniz.ml
+  DO +BENCH --name="ocaml" --lang="OCaml" --version="ocamlopt -version" --cmd="./leibniz"
 
 php:
   FROM +alpine --src="leibniz.php"

--- a/src/leibniz.ml
+++ b/src/leibniz.ml
@@ -1,0 +1,19 @@
+let calc rounds =
+  let sum = ref 0. in
+  let double = 2 * rounds in
+  let curr = ref (1 - double) in
+  let upto = double + 1 in
+  while !curr < upto do
+    sum := !sum +. 1. /. float_of_int !curr;
+    curr := !curr + 4
+  done;
+  !sum
+
+let () =
+  let rounds_txt = open_in_bin "rounds.txt" in
+  let rounds = int_of_string (input_line rounds_txt) in
+  close_in rounds_txt;
+
+  let pi = 4. *. calc rounds in
+  Printf.printf "%.16f\n" pi
+


### PR DESCRIPTION
Use imperative algorithm as OCaml compiler cannot unbox floats across function calls, see
https://discuss.ocaml.org/t/ocaml-speed-comparison-calculating-pi-with-leibniz-optimize/12112/2?u=yawaramin