### PR TITLE
Add NumPy, MyPyC, and Cinder implementations

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -38,6 +38,13 @@ PREPARE_ALPINE:
   COMMAND
   RUN apk add --no-cache hyperfine
 
+PREPARE_FEDORA:
+  COMMAND
+  RUN yum install -y wget
+  RUN wget https://github.com/sharkdp/hyperfine/releases/download/v1.15.0/hyperfine-v1.15.0-x86_64-unknown-linux-gnu.tar.gz
+  RUN tar -xzf hyperfine-v1.15.0-x86_64-unknown-linux-gnu.tar.gz
+  RUN cp hyperfine-v1.15.0-x86_64-unknown-linux-gnu/hyperfine /usr/local/bin/
+
 ADD_FILES:
   COMMAND
   ARG --required src
@@ -326,6 +333,12 @@ pony-nightly:
   DO +ADD_FILES --src="leibniz.pony"
   RUN --no-cache ponyc ./ -o=out --bin-name=leibniz
   DO +BENCH --name "pony-nightly" --lang="Pony(nightly)" --version="ponyc --version" --cmd="./out/leibniz"
+
+cinder:
+  FROM ghcr.io/facebookincubator/cinder-runtime:cinder-3.8
+  DO +PREPARE_FEDORA
+  DO +ADD_FILES --src="leibniz_mypyc.py"
+  DO +BENCH --name="cinder" --lang="Python (Cinder)" --version="python3 --version" --cmd="python3 -X jit leibniz_mypyc.py"
 
 cpython:
   FROM python:3.11-alpine

--- a/Earthfile
+++ b/Earthfile
@@ -24,7 +24,7 @@ BENCH:
   ARG --required version
   ARG index=0
 
-  RUN --no-cache hyperfine "$cmd" --warmup $warmups --runs $iterations --time-unit $timeas --export-json "./hyperfine.json" --output "./pi.txt" 
+  RUN --no-cache hyperfine "$cmd" --warmup $warmups --runs $iterations --time-unit $timeas --export-json "./hyperfine.json" --output "./pi.txt"
   RUN --no-cache ./scmeta --lang-name="$lang" --lang-version="$version" --hyperfine="./hyperfine.json" --pi="./pi.txt" --output="./scmeta.json" --lang-version-match-index="$index"
   SAVE ARTIFACT ./scmeta.json AS LOCAL ./results/$name.json
 
@@ -95,6 +95,9 @@ collect-data:
   BUILD +pony
   BUILD +pony-nightly
   BUILD +cpython
+  BUILD +cinder
+  BUILD +mypyc
+  BUILD +cpython-numpy
   BUILD +pypy
   BUILD +r
   BUILD +ruby

--- a/Earthfile
+++ b/Earthfile
@@ -333,6 +333,14 @@ cpython:
   DO +ADD_FILES --src="leibniz.py"
   DO +BENCH --name="cpython" --lang="Python (CPython)" --version="python3 --version" --cmd="python3 leibniz.py"
 
+cpython-numpy:
+  FROM python:3.11-alpine
+  DO +PREPARE_ALPINE
+  RUN apk add --no-cache gcc build-base
+  RUN python3 -m pip install numpy
+  DO +ADD_FILES --src="leibniz_np.py"
+  DO +BENCH --name="cpython-numpy" --lang="Python (CPython w/ NumPy)" --version="python3 --version" --cmd="python3 leibniz_np.py"
+
 pypy:
   # There is no pypy package on alpine
   # We use the standard which is Debian

--- a/Earthfile
+++ b/Earthfile
@@ -24,7 +24,7 @@ BENCH:
   ARG --required version
   ARG index=0
 
-  RUN --no-cache hyperfine "$cmd" --warmup $warmups --runs $iterations --time-unit $timeas --export-json "./hyperfine.json" --output "./pi.txt"
+  RUN --no-cache hyperfine "$cmd" --warmup $warmups --runs $iterations --time-unit $timeas --export-json "./hyperfine.json" --output "./pi.txt" 
   RUN --no-cache ./scmeta --lang-name="$lang" --lang-version="$version" --hyperfine="./hyperfine.json" --pi="./pi.txt" --output="./scmeta.json" --lang-version-match-index="$index"
   SAVE ARTIFACT ./scmeta.json AS LOCAL ./results/$name.json
 
@@ -340,6 +340,15 @@ cpython-numpy:
   RUN python3 -m pip install numpy
   DO +ADD_FILES --src="leibniz_np.py"
   DO +BENCH --name="cpython-numpy" --lang="Python (CPython w/ NumPy)" --version="python3 --version" --cmd="python3 leibniz_np.py"
+
+mypyc:
+  FROM python:3.11-alpine
+  DO +PREPARE_ALPINE
+  RUN apk add --no-cache gcc build-base
+  RUN python3 -m pip install mypy
+  DO +ADD_FILES --src="leibniz_mypyc.py"
+  RUN mypyc leibniz_mypyc.py
+  DO +BENCH --name="mypyc" --lang="Python (MyPyC)" --version="python3 --version" --cmd="python3 -c 'import leibniz_mypyc'"
 
 pypy:
   # There is no pypy package on alpine

--- a/src/leibniz_mypyc.py
+++ b/src/leibniz_mypyc.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# coding=utf-8
+from typing import Iterable
+
+def my_sum(xs: Iterable[float]) -> float:
+    # we don't want to use the built in sum() because its already running mostly in a C optimized hot-path
+    total = 0.0
+    for x in xs:
+        total += x
+    return total
+
+def leibniz(n: int) -> float:
+    a = range(1 - 2*n, 2*n + 1, 4)
+    b = (1.0 / float(i) for i in a)
+    return 4.0 * my_sum(b)
+
+def main() -> None:
+    with open("rounds.txt") as file:
+        rounds = int(file.read())
+
+    n = rounds
+    pi = leibniz(n)
+
+    print("{:.16f}".format(pi))
+
+main()

--- a/src/leibniz_np.py
+++ b/src/leibniz_np.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+import numpy as np
+
+def main():
+    with open("rounds.txt") as file:
+        rounds = int(file.read())
+
+    n = rounds
+    pi = 4 * (1 / np.arange(1 - 2*n, 2*n + 1, 4)).sum()
+
+    print("{:.16f}".format(pi))
+
+main()


### PR DESCRIPTION
# Implementations for 3 different Python alternatives.

[MyPyC](https://github.com/mypyc/mypyc) - A static compiler for Python using type hints to generate C extensions
[NumPy](https://github.com/numpy/numpy) - The fundamental package for scientific computing with Python. Rather ubiquitous and written in C
[Cinder](https://github.com/facebookincubator/cinder) - A fork of CPython that can do JIT using type annotations.

---

Let me know if you have questions or feedback.