### PR TITLE
Optimize pi calculation using unsafe operations

### DIFF
--- a/src/leibniz.rkt
+++ b/src/leibniz.rkt
@@ -1,16 +1,15 @@
-(module* three #f
-  (#%declare #:unsafe)
-  (require (rename-in racket/unsafe/ops
-                      [unsafe-fl- fl-]
-                      [unsafe-fl+ fl+]
-                      [unsafe-fl/ fl/]
-                      [unsafe-fl* fl*])
-           #;racket/flonum)
-  (time
-   (let ()
-     (define pi
-       (for/fold ([pi 1.0] [x 1.0] #:result (* pi 4.0))
-                 ([i (in-range 2.0 (+ rounds 2.0))])
-         (let ([x (fl- x)])
-           (values (fl+ pi (fl/ x (fl- (fl* 2.0 i) 1.0))) x))))
-     (displayln (list 'three (real->decimal-string pi 16))))))
+#lang racket/base
+
+(require racket/file
+         racket/flonum)
+
+(define rounds (file->value "rounds.txt"))
+
+; use "pie" instead of "pi" to avoid confusion with racket's included "pi"
+(let ([stop (fl+ (exact->inexact rounds) 2.0)])
+  (let loop ([x (fl+ -1.0)]
+             [pie (fl+ 1.0)]
+             [i 2.0])
+    (if (fl>= i stop)
+        (displayln (real->decimal-string (* pie 4.0) 16))
+        (loop (fl- x) (fl+ pie (fl/ x (fl- (fl* 2.0 i) 1.0))) (fl+ i 1.0)))))


### PR DESCRIPTION
Refactor Leibniz formula implementation to use unsafe operations and improve performance.

I asked someone from the Racket community to improve the existing code, as it seemed to be very out of fashion from Racket to be so slow before.

They got a ~12x improvement using unsafe flonum operations, so that would put Racket roughly in the 2.3s category.

They meant, this here is more idiomatic.