### PR TITLE
Speedup raku version using native intermediaries

### DIFF
--- a/src/leibniz.raku
+++ b/src/leibniz.raku
@@ -1,13 +1,17 @@
 #!/usr/bin/env raku
 
-my $rounds = "rounds.txt".IO.slurp.trim.Int;
+my int $rounds = "rounds.txt".IO.slurp.trim.Int + 2;
 
 my num $x = 1e0;
 my num $pi = 1e0;
+my num $w;
+my num $y;
 
-loop (my int $i = 2; $i <= $rounds + 2; $i++) {
+loop (my int $i = 2; $i <= $rounds; $i++) {
     $x *= -1e0;
-    $pi += $x / (2 * $i - 1);
+    $y = 2 * $i - 1;
+    $w = $x / $y;
+    $pi += $w;
 }
 
 $pi *= 4e0;


### PR DESCRIPTION
Otherwise the intermediate calculations are done with non-native implementations of the operators, resulting in lots of conversions.