### PR TITLE
Use juliaup installer instead of repo bundle julia installs

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -633,34 +633,40 @@ janet-compiled:
   DO +BENCH --name="janet-compiled" --lang="Janet (compiled)" --version="janet --version" --cmd="./leibniz"
 
 julia:
-  FROM julia:1.12
+  FROM ubuntu:latest
   DO +PREPARE_DEBIAN
   DO +ADD_FILES --src="leibniz.jl"
-  RUN apt-get update && apt-get install -y gcc
-  RUN julia -e 'print(VERSION); using Pkg; Pkg.activate("."); Pkg.update(); Pkg.Apps.add(["JuliaC"])'
+  RUN apt-get update && apt-get install -y clang curl
+  RUN curl -fsSL https://install.julialang.org | sh -s -- -y
+  ENV PATH="$HOME/.juliaup/bin/:$HOME/.julia/bin/:${PATH}"
+  RUN juliaup add 1.12
+  RUN julia -e 'using Pkg; Pkg.activate("."); Pkg.update(); Pkg.Apps.add(["JuliaC"])'
   RUN ~/.julia/bin/juliac \
         --output-exe leibniz \
         --trim \
         --experimental \
-        --bundle bun \
+        --bundle leibnizjl \
         --project . \
         leibniz.jl
-  DO +BENCH --name="julia" --lang="Julia" --version="julia --version" --cmd="bun/bin/leibniz"
+  DO +BENCH --name="julia" --lang="Julia" --version="julia --version" --cmd="leibnizjl/bin/leibniz"
 
 julia-ux4:
-  FROM julia:1.12
+  FROM ubuntu:latest
   DO +PREPARE_DEBIAN
   DO +ADD_FILES --src="leibniz_ux4.jl"
-  RUN apt-get update && apt-get install -y gcc
-  RUN julia -e 'print(VERSION); using Pkg; Pkg.activate("."); Pkg.update(); Pkg.Apps.add(["JuliaC"])'
+  RUN apt-get update && apt-get install -y clang curl
+  RUN curl -fsSL https://install.julialang.org | sh -s -- -y
+  ENV PATH="$HOME/.juliaup/bin/:$HOME/.julia/bin/:${PATH}"
+  RUN juliaup add 1.12
+  RUN julia -e 'using Pkg; Pkg.activate("."); Pkg.update(); Pkg.Apps.add(["JuliaC"])'
   RUN ~/.julia/bin/juliac \
         --output-exe leibniz \
         --trim \
         --experimental \
-        --bundle bun \
+        --bundle leibnizjl-ux4 \
         --project . \
         leibniz_ux4.jl
-  DO +BENCH --name="julia-ux4" --lang="Julia (ux4)" --version="julia --version" --cmd="bun/bin/leibniz"
+  DO +BENCH --name="julia" --lang="Julia" --version="julia --version" --cmd="leibnizjl-ux4/bin/leibniz"
 
 objc:
   FROM +alpine --src="leibniz.m"

--- a/src/leibniz.jl
+++ b/src/leibniz.jl
@@ -1,7 +1,7 @@
 function f(rounds)
     pi = 1.0
     @fastmath @simd for i in 2:(rounds + 2)
-        pi += (iseven(i) ? -1 : 1) / (2*i - 1)
+        pi += (iseven(i) ? -1.0 : 1.0) / (2*i - 1)
     end
     return pi*4
 end

--- a/src/leibniz_ux4.jl
+++ b/src/leibniz_ux4.jl
@@ -3,14 +3,14 @@ function f(rounds)
     r2 = rounds + 2
     vend = r2 - r2 % 4
     @simd for i in 4:8:(r2*2)
-        pi += inv(i -  1.0) -
-              inv(i +  1.0) +
-              inv(i +  3.0) -
-              inv(i +  5.0)
+        pi += inv(i -  1) -
+              inv(i +  1) +
+              inv(i +  3) -
+              inv(i +  5)
     end
     pi = -pi
     for i in vend+1:r2
-        pi += 1.0 / (2.0 * i - 1.0)
+        pi += 1 / (2 * i - 1)
     end
     return pi*4
 end
@@ -20,3 +20,4 @@ function (@main)(ARGS)
     print(Core.stdout, f(rounds))
     0
 end
+


### PR DESCRIPTION
I have a suspicion that the `FROM julia:1.12` is the culprit behind https://github.com/niklas-heer/speed-comparison/issues/146. I suspect that for whatever reason that julia installation doesn't vectorize properly on the machine that's benchmarking. This can sometimes happen because package managers often insist on linking Julia against their OS-level LLVM install which is missing patches that julia uses, so https://github.com/JuliaLang/juliaup is the official way to install julia. 

Testing this to see if it helps (I also cleaned up the `leibniz.jl` and `leibniz_ux4.jl` files a little which should make `/bench changed` work properly here).

I'd also suggest we just delete that weird `leibnix_ux4.jl` implementation, I don't really get why it was ever included, but whatever. 