### PR TITLE
Add chez scheme

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -156,6 +156,7 @@ collect-data:
   BUILD +gleam
   BUILD +haskell
   BUILD +ocaml
+  BUILD +chezscheme
   BUILD +racket
   BUILD +sbcl
   # Scripting languages
@@ -456,6 +457,14 @@ ocaml:
   DO +ADD_FILES --src="leibniz.ml"
   RUN --no-cache ocamlopt -O2 -o leibniz leibniz.ml
   DO +BENCH --name="ocaml" --lang="OCaml" --version="ocamlopt -version" --cmd="./leibniz"
+
+chezscheme:
+  FROM alpine:edge
+  DO +PREPARE_ALPINE
+  RUN apk add --no-cache chez-scheme
+  DO +ADD_FILES --src="leibniz.ss"
+  RUN --no-cache echo '(compile-program "leibniz.ss")' | chez --optimize-level 3
+  DO +BENCH --name="chez" --lang="Chez Scheme" --version="chez --version" --cmd="chez --program leibniz.so"
 
 racket:
   FROM alpine:edge

--- a/src/leibniz.ss
+++ b/src/leibniz.ss
@@ -1,0 +1,13 @@
+(import (chezscheme))
+
+(define rounds (with-input-from-file "rounds.txt" read))
+
+(let ([stop (fx+ rounds 2)])
+  (let loop ([i 2]
+             [x -1.0]
+             [pie 1.0])
+    (if (fx> i stop)
+        (display (format "~,16f\n" (fl* pie 4.0)))
+        (loop (fx+ i 1)
+              (fl- 0.0 x)
+              (fl+ pie (fl/ x (fl- (fl* 2.0 (fixnum->flonum i)) 1.0)))))))


### PR DESCRIPTION
Chez Scheme is a R6RS-compliant Scheme implementation. It's generally considered the fastest implementation of the Scheme branch of the Lisp family.

It's worth adding to compare with:
1. Racket, which is built on top of Chez Scheme, which lets you see how much "overhead" Racket introduces.
2. SBCL, the fastest implementation of the Common Lisp side of the family


The implementation itself is basically copied from Racket, but calling the standard versions of the math operators and with the final print adapted. The compiler will omit type safety checks in --optimize-level 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and benchmarking Chez Scheme programs.
  * Chez Scheme compiler is now integrated into the data collection pipeline, enabling performance metrics to be gathered alongside other language implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->