### PR TITLE
Speedup C# version by using double type for rounds variable

### DIFF
--- a/src/leibniz.cs
+++ b/src/leibniz.cs
@@ -1,4 +1,4 @@
-var rounds = int.Parse(File.ReadAllText("rounds.txt"));
+var rounds = double.Parse(File.ReadAllText("rounds.txt"));
 
 var pi = 1.0D;
 var x = 1.0D;


### PR DESCRIPTION
This implementation was consistently faster in my testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated round value parsing to support decimal values instead of whole numbers, with corresponding adjustments to iteration boundaries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->