### PR TITLE
Add "Download CSV" Button

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -875,7 +875,7 @@
                 document.body.appendChild(link);
                 link.click();
                 document.body.removeChild(link);
-                URL.revokeObjectURL(url);
+                setTimeout(() => URL.revokeObjectURL(url), 100);
             }
 
             function handleDownloadCSV() {


### PR DESCRIPTION
Hi,
I added a button that allows you to download data to a CSV file, if you want to make your own chart or compare data in another way, it is inconvenient to copy them from the current table on the website.


<img width="503" height="130" alt="image" src="https://github.com/user-attachments/assets/dcfc6d5a-72a8-4be4-8a5c-992d41e05df3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV export added so users can download table data; export respects active search filters and current view.
  * Download button added to the table header, disabled until data loads and enabled after results render.

* **Enhancements**
  * Exports use a fixed primary-column order, omit internal-only columns, escape special characters, and derive filename from the selected run.
  * Responsive layout: download control adapts on small viewports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->