### PR TITLE
Elixir: Use private functions to improve performance

### DIFF
--- a/src/leibniz.ex
+++ b/src/leibniz.ex
@@ -8,13 +8,13 @@ defmodule Leibniz do
     IO.puts pi
   end
 
-  def calculate(x, pi, i, stop) when i <= stop do
+  defp calculate(x, pi, i, stop) when i <= stop do
     x_new = -x
     pi_new = pi + (x_new / (2 * i - 1))
     calculate(x_new, pi_new, i + 1, stop)
   end
 
-  def calculate(_x, pi, _i, _stop) do
+  defp calculate(_x, pi, _i, _stop) do
     pi * 4.0
   end
 end


### PR DESCRIPTION
In Erlang/Elixir, public functions are indirect calls, which allows for hot code reloads of modules at runtime.

This indirection obviously is not free and costs performance. By defining "calculate" as "private" (defp), performance improves by roughly 2x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->