### PR TITLE
Add a seperate simd zig version

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -138,6 +138,7 @@ collect-data:
   BUILD +rust-nightly
   BUILD +v
   BUILD +zig
+  BUILD +zig-simd
   # JVM languages
   BUILD +clj
   BUILD +groovy
@@ -322,6 +323,13 @@ zig:
   DO +ADD_FILES --src="leibniz.zig"
   RUN --no-cache zig build-exe -OReleaseFast leibniz.zig
   DO +BENCH --name="zig" --lang="Zig" --version="zig version" --cmd="./leibniz"
+
+zig-simd:
+  FROM alpine:edge
+  RUN apk add --no-cache hyperfine zig --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+  DO +ADD_FILES --src="leibniz-simd.zig"
+  RUN --no-cache zig build-exe -OReleaseFast leibniz-simd.zig
+  DO +BENCH --name="zig-simd" --lang="Zig" --version="zig version" --cmd="./leibniz-simd"
 
 # ============================================================================
 # JVM LANGUAGES (Java, Kotlin, Scala, Clojure, Groovy)

--- a/dagger-poc/languages.py
+++ b/dagger-poc/languages.py
@@ -225,7 +225,7 @@ LANGUAGES: dict[str, Language] = {
     ),
     "zig": Language(
         name="Zig",
-        nixpkgs=("zig@0.15.2",),
+        nixpkgs=("zig@0.16.0",),
         file="leibniz.zig",
         compile="zig build-exe -OReleaseFast leibniz.zig -fno-stack-check",
         run="./leibniz",

--- a/src/leibniz-simd.zig
+++ b/src/leibniz-simd.zig
@@ -1,0 +1,47 @@
+const std = @import("std");
+
+// Vector length 8 for 512 bit wide target cpus
+const Vf = @Vector(8, f64);
+const Vu = @Vector(8, u64);
+
+const signs: Vf = .{ -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0 };
+const offset: Vu = .{ 3, 5, 7, 9, 11, 13, 15, 17 };
+const v_2: Vu = @splat(2);
+
+pub fn main() !void {
+    // like C -ffast-math
+    @setFloatMode(.optimized);
+
+    // Zig 0.16+ Io interface - file access requires an Io implemention
+    var threaded = std.Io.Threaded.init_single_threaded;
+    const io = threaded.io();
+
+    var file = try std.Io.Dir.cwd().openFile(io, "rounds.txt", .{});
+    defer file.close(io);
+    var buffer: [1024]u8 = undefined;
+    const n = try file.readPositionalAll(io, &buffer, 0);
+    const rounds = try std.fmt.parseUnsigned(u64, buffer[0..n], 10);
+
+    var i: usize = 0;
+    var V_pi: Vf = @splat(0.0);
+    while (i <= (rounds - 8)) : (i += 8) {
+        const div: Vu = v_2 * @as(Vu, @splat(i)) + offset;
+
+        V_pi += signs / @as(Vf, @floatFromInt(div));
+    }
+
+    var pi: f64 = 1.0 + @reduce(.Add, V_pi);
+
+    // remaining iterations
+    for (i..rounds) |itr| {
+        const x: f64 = -1.0 + 2.0 * @as(f64, @floatFromInt(itr & 1));
+        pi += (x / @as(f64, @floatFromInt(2 * itr - 1)));
+    }
+    pi *= 4;
+
+    var output_buf: [64]u8 = undefined;
+    var writer = std.Io.File.stdout().writer(io, &output_buf);
+
+    try writer.interface.print("{d:.16}", .{pi});
+    try writer.interface.flush();
+}

--- a/src/leibniz-simd.zig
+++ b/src/leibniz-simd.zig
@@ -20,7 +20,7 @@ pub fn main() !void {
     defer file.close(io);
     var buffer: [1024]u8 = undefined;
     const n = try file.readPositionalAll(io, &buffer, 0);
-    const rounds = try std.fmt.parseUnsigned(u64, std.mem.trim(u8, buffer[0..n], "\n"), 10);
+    const rounds = try std.fmt.parseInt(i64, std.mem.trim(u8, buffer[0..n], "\n"), 10);
 
     var i: usize = 0;
     var V_pi: Vf = @splat(0.0);
@@ -33,9 +33,9 @@ pub fn main() !void {
     var pi: f64 = 1.0 + @reduce(.Add, V_pi);
 
     // remaining iterations
-    for (i..rounds) |itr| {
-        const x: f64 = -1.0 + 2.0 * @as(f64, @floatFromInt(itr & 1));
-        pi += (x / @as(f64, @floatFromInt(2 * itr - 1)));
+    while (i < rounds) : (i += 1) {
+        const x: f64 = -1.0 + 2.0 * @as(f64, @floatFromInt(i & 1));
+        pi += (x / @as(f64, @floatFromInt(2 * i + 3)));
     }
     pi *= 4;
 

--- a/src/leibniz-simd.zig
+++ b/src/leibniz-simd.zig
@@ -20,7 +20,7 @@ pub fn main() !void {
     defer file.close(io);
     var buffer: [1024]u8 = undefined;
     const n = try file.readPositionalAll(io, &buffer, 0);
-    const rounds = try std.fmt.parseUnsigned(u64, buffer[0..n], 10);
+    const rounds = try std.fmt.parseUnsigned(u64, std.mem.trim(u8, buffer[0..n], "\n"), 10);
 
     var i: usize = 0;
     var V_pi: Vf = @splat(0.0);

--- a/src/leibniz.zig
+++ b/src/leibniz.zig
@@ -12,7 +12,7 @@ pub fn main() !void {
     defer file.close(io);
     var buffer: [1024]u8 = undefined;
     const n = try file.readPositionalAll(io, &buffer, 0);
-    const rounds = try std.fmt.parseUnsigned(u64, buffer[0..n], 10) + 2;
+    const rounds = try std.fmt.parseUnsigned(u64, std.mem.trim(u8, buffer[0..n], "\n"), 10) + 2;
 
     var i: usize = 2;
     var pi: f64 = 1.0;

--- a/src/leibniz.zig
+++ b/src/leibniz.zig
@@ -12,7 +12,7 @@ pub fn main() !void {
     defer file.close(io);
     var buffer: [1024]u8 = undefined;
     const n = try file.readPositionalAll(io, &buffer, 0);
-    const rounds = try std.fmt.parseUnsigned(u64, std.mem.trim(u8, buffer[0..n], "\n"), 10) + 2;
+    const rounds = try std.fmt.parseInt(i64, std.mem.trim(u8, buffer[0..n], "\n"), 10) + 2;
 
     var i: usize = 2;
     var pi: f64 = 1.0;

--- a/src/leibniz.zig
+++ b/src/leibniz.zig
@@ -4,11 +4,15 @@ pub fn main() !void {
     // like C -ffast-math
     @setFloatMode(.optimized);
 
-    var file = try std.fs.cwd().openFile("rounds.txt", .{});
-    defer file.close();
+    // Zig 0.16+ Io interface - file access requires an Io implemention
+    var threaded = std.Io.Threaded.init_single_threaded;
+    const io = threaded.io();
+
+    var file = try std.Io.Dir.cwd().openFile(io, "rounds.txt", .{});
+    defer file.close(io);
     var buffer: [1024]u8 = undefined;
-    const n = try file.readAll(buffer[0..buffer.len]);
-    const rounds = try std.fmt.parseInt(i64, std.mem.trim(u8, buffer[0..n], "\n"), 10) + 2;
+    const n = try file.readPositionalAll(io, &buffer, 0);
+    const rounds = try std.fmt.parseUnsigned(u64, buffer[0..n], 10) + 2;
 
     var i: usize = 2;
     var pi: f64 = 1.0;
@@ -18,9 +22,9 @@ pub fn main() !void {
     }
     pi *= 4;
 
-    // Zig 0.15+ stdout API - use format to buffer, then write directly
     var output_buf: [64]u8 = undefined;
-    const output = std.fmt.bufPrint(&output_buf, "{d:.16}", .{pi}) catch unreachable;
-    const stdout = std.fs.File.stdout();
-    _ = try stdout.write(output);
+    var writer = std.Io.File.stdout().writer(io, &output_buf);
+
+    try writer.interface.print("{d:.16}", .{pi});
+    try writer.interface.flush();
 }


### PR DESCRIPTION
There are a couple regressions in zig 0.16.0:
- autovectorization is disabled due to an LLVM bug
- the new Io interface adds a lot of unused code. Compile times are a lot slower

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SIMD-optimized Zig implementation for calculating π.
  * Added a dedicated `zig-simd` benchmark and included it in aggregate data collection.

* **Improvements**
  * Updated the existing Zig implementation for compatibility with the latest supported toolchain.
  * Improved numeric parsing and input/output handling.
  * Updated benchmark configuration to use Zig 0.16.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->