### PR TITLE
Resolve Python language declarations through a validated Dagger manifest

### DIFF
--- a/dagger-poc/README.md
+++ b/dagger-poc/README.md
@@ -40,6 +40,11 @@ The directory keeps its original name to preserve scripts and dependency update
 paths. Use `just` inside this directory for convenience commands. `uv sync --extra
 dev` installs pytest and the development tooling.
 
+The optional [catalog resolver](../docs/catalog-resolution.md) preserves these
+Python declarations while exporting validated data through a Dagger container. It
+is a prerequisite for future authorized PR execution; it does not change the active
+benchmark adapter or enable automatic dispatch.
+
 For a new language, add a `Language` entry and its source, run the tests, then run
 a native smoke test. Validate small odd/even round counts and SIMD tail handling.
 Variants need distinct display names. Keep package versions explicit; flake inputs

--- a/dagger-poc/catalog_export.py
+++ b/dagger-poc/catalog_export.py
@@ -1,0 +1,45 @@
+"""Container-side export helper. Execute unreviewed catalogs only in an isolated runner.
+
+This file intentionally depends only on the standard library. The trusted resolver
+supplies it separately from the catalog being evaluated. Its output is untrusted
+until catalog_manifest.load_manifest validates it in the calling client.
+"""
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", type=Path, required=True)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    digest = hashlib.sha256(args.catalog.read_bytes()).hexdigest()
+    spec = importlib.util.spec_from_file_location("benchmark_catalog_input", args.catalog)
+    if spec is None or spec.loader is None:
+        raise ValueError("Cannot load catalog")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    result = {
+        "schema_version": 1,
+        "source_revision": args.revision,
+        "catalog_sha256": digest,
+        "tooling": {
+            "devbox_image": module.get_devbox_image(),
+            "hyperfine": module.HYPERFINE_VERSION,
+            "micropython": module.MICROPYTHON_VERSION,
+        },
+        "languages": {target: asdict(lang) for target, lang in module.LANGUAGES.items()},
+    }
+    args.output.write_text(json.dumps(result, sort_keys=True, allow_nan=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/dagger-poc/catalog_manifest.py
+++ b/dagger-poc/catalog_manifest.py
@@ -121,6 +121,8 @@ def load_manifest(payload: str, *, source_revision: str, catalog_sha256: str) ->
         for key in ("name", "base", "category"):
             if config[key] is not None and any(ord(c) < 32 for c in config[key]):
                 raise ValueError(f"{target}.{key}: control characters are not allowed")
+        if config["base"] is not None and not re.fullmatch(TARGET_PATTERN, config["base"]):
+            raise ValueError(f"{target}: invalid base-image identifier")
         for key in LIST_FIELDS:
             if not isinstance(config[key], list) or len(config[key]) > 256:
                 raise ValueError(f"{target}.{key}: expected a bounded list")

--- a/dagger-poc/catalog_manifest.py
+++ b/dagger-poc/catalog_manifest.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 import re
+import stat
+from contextlib import ExitStack
 from dataclasses import dataclass, fields
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 
 from languages import Language
 
@@ -145,3 +148,38 @@ def load_manifest(payload: str, *, source_revision: str, catalog_sha256: str) ->
             raise ValueError(f"{target}: version regex needs a capture group")
         languages[target] = Language(**config)
     return CatalogManifest(source_revision, catalog_sha256, dict(tooling), languages)
+
+
+def read_catalog_source(source_root: Path, relative: str) -> str:
+    """Read a regular UTF-8 file under a trusted root, without following PR symlinks."""
+    path = PurePosixPath(relative)
+    if (
+        not relative
+        or path.is_absolute()
+        or ".." in path.parts
+        or "\\" in relative
+        or path.as_posix() != relative
+        or relative == "."
+    ):
+        raise ValueError("Catalog must be a canonical path relative to the verified source root")
+    try:
+        with ExitStack() as stack:
+            directory = os.open(source_root, os.O_RDONLY | os.O_DIRECTORY)
+            stack.callback(os.close, directory)
+            for part in path.parts[:-1]:
+                directory = os.open(
+                    part, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW, dir_fd=directory
+                )
+                stack.callback(os.close, directory)
+            descriptor = os.open(
+                path.name, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=directory
+            )
+            with os.fdopen(descriptor, "rb") as source:
+                if not stat.S_ISREG(os.fstat(source.fileno()).st_mode):
+                    raise ValueError("Catalog must be a regular file")
+                data = source.read(MAX_MANIFEST_BYTES + 1)
+    except OSError as error:
+        raise ValueError("Cannot read catalog without following source symlinks") from error
+    if len(data) > MAX_MANIFEST_BYTES:
+        raise ValueError("Catalog source exceeds the size limit")
+    return data.decode("utf-8")

--- a/dagger-poc/catalog_manifest.py
+++ b/dagger-poc/catalog_manifest.py
@@ -1,0 +1,145 @@
+"""Validate data returned by an isolated catalog resolver; never import its source."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, fields
+from pathlib import PurePosixPath
+
+from languages import Language
+
+MAX_MANIFEST_BYTES = 4 * 1024 * 1024
+MAX_TARGETS = 512
+STRING_FIELDS = {"name", "file", "run", "category", "version_regex"}
+OPTIONAL_FIELDS = {"compile", "version_cmd", "base", "nix_setup"}
+LIST_FIELDS = {"extra_files", "nixpkgs", "nix_flakes", "allow_insecure"}
+TARGET_PATTERN = r"[a-z0-9][a-z0-9-]*"
+VERSION_PATTERN = r"[0-9][0-9A-Za-z.+_-]*"
+
+
+@dataclass(frozen=True)
+class CatalogManifest:
+    source_revision: str
+    catalog_sha256: str
+    tooling: dict[str, str]
+    languages: dict[str, Language]
+
+
+def _object(pairs: list[tuple[str, object]]) -> dict:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"Duplicate JSON key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _keys(value: object, expected: set[str], location: str) -> dict:
+    if not isinstance(value, dict) or set(value) != expected:
+        raise ValueError(f"{location}: expected exactly {sorted(expected)}")
+    return value
+
+
+def _string(value: object, location: str, *, optional: bool = False) -> str | None:
+    if optional and value is None:
+        return None
+    if (
+        not isinstance(value, str)
+        or (not optional and not value)
+        or len(value) > 131072
+        or "\0" in value
+    ):
+        raise ValueError(f"{location}: invalid string")
+    return value
+
+
+def _path(value: str) -> None:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or "\\" in value
+        or path.is_absolute()
+        or ".." in path.parts
+        or path.as_posix() != value
+        or value == "."
+        or any(ord(c) < 32 for c in value)
+    ):
+        raise ValueError("Source paths must be canonical relative POSIX paths")
+
+
+def load_manifest(payload: str, *, source_revision: str, catalog_sha256: str) -> CatalogManifest:
+    """Check identity against caller-owned values before constructing trusted types.
+
+    The caller must supply a verified source revision and the hash of the catalog
+    it sent to the resolver. The manifest itself is data, not an authorization token
+    or proof that a working directory matches the claimed Git revision.
+    """
+    if not re.fullmatch(r"[0-9a-f]{40}", source_revision):
+        raise ValueError("Expected a full source commit SHA")
+    if not re.fullmatch(r"[0-9a-f]{64}", catalog_sha256):
+        raise ValueError("Expected a SHA-256 catalog digest")
+    if len(payload.encode("utf-8")) > MAX_MANIFEST_BYTES:
+        raise ValueError("Catalog manifest exceeds the size limit")
+    try:
+        document = json.loads(payload, object_pairs_hook=_object)
+    except (json.JSONDecodeError, RecursionError) as error:
+        raise ValueError("Invalid catalog JSON") from error
+    _keys(
+        document,
+        {"schema_version", "source_revision", "catalog_sha256", "tooling", "languages"},
+        "manifest",
+    )
+    if type(document["schema_version"]) is not int or document["schema_version"] != 1:
+        raise ValueError("Unsupported catalog schema version")
+    if (
+        document["source_revision"] != source_revision
+        or document["catalog_sha256"] != catalog_sha256
+    ):
+        raise ValueError("Catalog identity does not match the requested source")
+    tooling = _keys(document["tooling"], {"devbox_image", "hyperfine", "micropython"}, "tooling")
+    for name, value in tooling.items():
+        _string(value, name)
+    if not re.fullmatch(r"[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}", tooling["devbox_image"]):
+        raise ValueError("Devbox image must have a pinned digest")
+    for key in ("hyperfine", "micropython"):
+        if not re.fullmatch(VERSION_PATTERN, tooling[key]):
+            raise ValueError(f"{key}: expected a pinned version")
+    entries = document["languages"]
+    if not isinstance(entries, dict) or not 1 <= len(entries) <= MAX_TARGETS:
+        raise ValueError("Invalid target count")
+    expected_fields = STRING_FIELDS | OPTIONAL_FIELDS | LIST_FIELDS
+    if expected_fields != {field.name for field in fields(Language)}:
+        raise ValueError("Language schema changed; update the manifest schema explicitly")
+    languages = {}
+    for target, value in entries.items():
+        if not re.fullmatch(TARGET_PATTERN, target):
+            raise ValueError("Invalid target identifier")
+        config = dict(_keys(value, expected_fields, target))
+        for key in STRING_FIELDS | OPTIONAL_FIELDS:
+            _string(config[key], f"{target}.{key}", optional=key in OPTIONAL_FIELDS)
+        for key in ("name", "base", "category"):
+            if config[key] is not None and any(ord(c) < 32 for c in config[key]):
+                raise ValueError(f"{target}.{key}: control characters are not allowed")
+        for key in LIST_FIELDS:
+            if not isinstance(config[key], list) or len(config[key]) > 256:
+                raise ValueError(f"{target}.{key}: expected a bounded list")
+            for item in config[key]:
+                _string(item, f"{target}.{key}")
+            config[key] = tuple(config[key])
+        for path in (config["file"], *config["extra_files"]):
+            _path(path)
+        for package in config["nixpkgs"]:
+            if not re.fullmatch(r"[A-Za-z0-9._+-]+@" + VERSION_PATTERN, package):
+                raise ValueError(f"{target}: invalid package declaration")
+        for package in config["allow_insecure"]:
+            if not re.fullmatch(r"[A-Za-z0-9._+-]+", package):
+                raise ValueError(f"{target}: invalid insecure-package exception")
+        try:
+            pattern = re.compile(config["version_regex"])
+        except re.error as error:
+            raise ValueError(f"{target}: invalid version regex") from error
+        if pattern.groups < 1:
+            raise ValueError(f"{target}: version regex needs a capture group")
+        languages[target] = Language(**config)
+    return CatalogManifest(source_revision, catalog_sha256, dict(tooling), languages)

--- a/dagger-poc/catalog_resolver.py
+++ b/dagger-poc/catalog_resolver.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Resolve Python declarations through Dagger without importing the input on the client.
+
+Run this trusted driver separately from any unreviewed source checkout. The caller
+owns revision authorization and must supply a verified commit snapshot. This helper
+alone does not authorize PR execution or establish an isolated homelab runner.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import re
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+import dagger
+
+from catalog_manifest import MAX_MANIFEST_BYTES, CatalogManifest, load_manifest
+
+RESOLVER_IMAGE = (
+    "python:3.12-slim@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea"
+)
+EXPORTER = Path(__file__).with_name("catalog_export.py")
+
+
+async def resolve_catalog(
+    client: dagger.Client,
+    catalog: dagger.File,
+    *,
+    source_revision: str,
+) -> CatalogManifest:
+    """Evaluate only the supplied catalog in a credential-free container.
+
+    No host directory, socket, secret or caller environment is mounted. The exporter
+    comes from this driver's trusted checkout. Its output is treated as untrusted
+    data, including the revision/digest fields it returns.
+    """
+    if not re.fullmatch(r"[0-9a-f]{40}", source_revision):
+        raise ValueError("Expected a verified full source commit SHA")
+    async with asyncio.timeout(120):
+        if await catalog.size() > MAX_MANIFEST_BYTES:
+            raise ValueError("Catalog source exceeds the size limit")
+        contents = await catalog.contents()
+        digest = hashlib.sha256(contents.encode("utf-8")).hexdigest()
+        container = (
+            client.container()
+            .from_(RESOLVER_IMAGE)
+            .with_file("/input/languages.py", catalog)
+            .with_new_file("/tools/export.py", contents=EXPORTER.read_text())
+            .with_exec(["mkdir", "-p", "/out"])
+            .with_exec(
+                [
+                    "timeout",
+                    "--kill-after=2s",
+                    "30s",
+                    "python",
+                    "-I",
+                    "/tools/export.py",
+                    "--catalog",
+                    "/input/languages.py",
+                    "--revision",
+                    source_revision,
+                    "--output",
+                    "/out/catalog.json",
+                ]
+            )
+        )
+        output = container.file("/out/catalog.json")
+        if await output.size() > MAX_MANIFEST_BYTES:
+            raise ValueError("Resolved catalog exceeds the size limit")
+        payload = await output.contents()
+        return load_manifest(payload, source_revision=source_revision, catalog_sha256=digest)
+
+
+def encode_manifest(manifest: CatalogManifest) -> str:
+    """Write the validated model in canonical JSON form, retaining all language fields."""
+    return json.dumps({"schema_version": 1, **asdict(manifest)}, sort_keys=True, indent=2) + "\n"
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", type=Path, required=True)
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
+        manifest = await resolve_catalog(
+            client,
+            client.host().file(str(args.catalog.resolve())),
+            source_revision=args.source_revision,
+        )
+    args.output.write_text(encode_manifest(manifest))
+    print(f"Validated {len(manifest.languages)} targets; catalog SHA-256 {manifest.catalog_sha256}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/dagger-poc/catalog_resolver.py
+++ b/dagger-poc/catalog_resolver.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import dagger
 
-from catalog_manifest import MAX_MANIFEST_BYTES, CatalogManifest, load_manifest
+from catalog_manifest import MAX_MANIFEST_BYTES, CatalogManifest, load_manifest, read_catalog_source
 
 RESOLVER_IMAGE = (
     "python:3.12-slim@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea"
@@ -83,14 +83,18 @@ def encode_manifest(manifest: CatalogManifest) -> str:
 
 async def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--catalog", type=Path, required=True)
+    parser.add_argument("--source-root", type=Path, required=True)
+    parser.add_argument("--catalog", default="dagger-poc/languages.py")
     parser.add_argument("--source-revision", required=True)
     parser.add_argument("--output", type=Path, required=True)
     args = parser.parse_args()
+    contents = read_catalog_source(args.source_root, args.catalog)
     async with dagger.Connection(dagger.Config(log_output=sys.stderr)) as client:
         manifest = await resolve_catalog(
             client,
-            client.host().file(str(args.catalog.resolve())),
+            client.directory()
+            .with_new_file("languages.py", contents=contents)
+            .file("languages.py"),
             source_revision=args.source_revision,
         )
     args.output.write_text(encode_manifest(manifest))

--- a/dagger-poc/catalog_resolver.py
+++ b/dagger-poc/catalog_resolver.py
@@ -25,6 +25,13 @@ RESOLVER_IMAGE = (
     "python:3.12-slim@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea"
 )
 EXPORTER = Path(__file__).with_name("catalog_export.py")
+# Explicit empty values suppress Dagger's engine-proxy inheritance. Removing these
+# variables would re-enable inheritance at exec time (Dagger 0.19.8 setProxyEnvs).
+PROXY_ENV_NAMES = tuple(
+    name
+    for upper in ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY", "FTP_PROXY")
+    for name in (upper, upper.lower())
+)
 
 
 async def resolve_catalog(
@@ -51,7 +58,11 @@ async def resolve_catalog(
             .from_(RESOLVER_IMAGE)
             .with_file("/input/languages.py", catalog)
             .with_new_file("/tools/export.py", contents=EXPORTER.read_text())
-            .with_exec(["mkdir", "-p", "/out"])
+        )
+        for name in PROXY_ENV_NAMES:
+            container = container.with_env_variable(name, "")
+        container = (
+            container.with_exec(["mkdir", "-p", "/out"])
             .with_exec(
                 [
                     "timeout",

--- a/dagger-poc/check_catalog_resolver.py
+++ b/dagger-poc/check_catalog_resolver.py
@@ -16,7 +16,7 @@ from tempfile import TemporaryDirectory
 
 import dagger
 
-from catalog_resolver import RESOLVER_IMAGE, resolve_catalog
+from catalog_resolver import PROXY_ENV_NAMES, RESOLVER_IMAGE, resolve_catalog
 from languages import LANGUAGES
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -52,11 +52,45 @@ async def check() -> dict:
                     'LANGUAGES = {"go": replace(LANGUAGES["go"], '
                     f'name=os.environ.get({environment_key!r}, "not-forwarded"))}}\n'
                 )
+                text += (
+                    f"\nassert all(os.environ.get(name) == '' for name in {PROXY_ENV_NAMES!r})\n"
+                )
                 fixture.write_text(text)
                 result = await resolve_catalog(
                     client, client.host().file(str(fixture)), source_revision=revision
                 )
                 assert result.languages["go"].name == "not-forwarded"
+
+                class ProxyConfiguredContainer:
+                    def from_(self, image):
+                        container = client.container().from_(image)
+                        for name in PROXY_ENV_NAMES:
+                            container = container.with_env_variable(
+                                name, "http://fake-user:fake-password@127.0.0.1:9"
+                            )
+                        return container
+
+                class ProxyConfiguredClient:
+                    """Seed fake proxy configuration after image configuration is loaded."""
+
+                    def container(self):
+                        return ProxyConfiguredContainer()
+
+                seeded = ProxyConfiguredContainer().from_(RESOLVER_IMAGE)
+                await seeded.with_exec([
+                    "python", "-c",
+                    "import os; "
+                    f"assert all(os.environ.get(n) == "
+                    f"'http://fake-user:fake-password@127.0.0.1:9' for n in {PROXY_ENV_NAMES!r})",
+                ]).sync()
+                proxy_result = await resolve_catalog(
+                    ProxyConfiguredClient(),
+                    client.host().file(str(fixture)),
+                    source_revision=revision,
+                )
+                assert proxy_result.languages == result.languages
+                evidence["explicit_fake_proxy_credentials_cleared"] = True
+                evidence["standard_proxy_environment_empty"] = True
                 assert not marker.exists(), "Catalog code wrote to the client filesystem"
                 evidence["client_environment_not_forwarded"] = True
                 evidence["container_side_effect_absent_on_client"] = True

--- a/dagger-poc/check_catalog_resolver.py
+++ b/dagger-poc/check_catalog_resolver.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Optional real-Dagger check of catalog parity and the client/container boundary."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import subprocess
+import uuid
+from importlib.metadata import version
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import dagger
+
+from catalog_resolver import RESOLVER_IMAGE, resolve_catalog
+from languages import LANGUAGES
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+async def check() -> dict:
+    revision = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip()
+    catalog = ROOT / "dagger-poc/languages.py"
+    environment_key = "SPEED_CATALOG_CLIENT_" + uuid.uuid4().hex.upper()
+    os.environ[environment_key] = "client-only-test-value"
+    marker = Path("/tmp") / ("speed-catalog-sentinel-" + uuid.uuid4().hex)
+    evidence = {
+        "source_revision": revision,
+        "resolver_image": RESOLVER_IMAGE,
+        "dagger_sdk": version("dagger-io"),
+    }
+    try:
+        with TemporaryDirectory(prefix="speed-catalog-check-") as directory:
+            async with dagger.Connection() as client:
+                full = await resolve_catalog(
+                    client, client.host().file(str(catalog)), source_revision=revision
+                )
+                assert full.languages == LANGUAGES
+                assert full.catalog_sha256 == hashlib.sha256(catalog.read_bytes()).hexdigest()
+                evidence["targets_round_tripped"] = len(full.languages)
+                evidence["catalog_sha256"] = full.catalog_sha256
+                fixture = Path(directory) / "catalog.py"
+                text = catalog.read_text()
+                text += (
+                    "\nfrom pathlib import Path\nfrom dataclasses import replace\n"
+                    f'Path({str(marker)!r}).write_text("container only")\n'
+                    'print("catalog stdout is not JSON")\n'
+                    'LANGUAGES = {"go": replace(LANGUAGES["go"], '
+                    f'name=os.environ.get({environment_key!r}, "not-forwarded"))}}\n'
+                )
+                fixture.write_text(text)
+                result = await resolve_catalog(
+                    client, client.host().file(str(fixture)), source_revision=revision
+                )
+                assert result.languages["go"].name == "not-forwarded"
+                assert not marker.exists(), "Catalog code wrote to the client filesystem"
+                evidence["client_environment_not_forwarded"] = True
+                evidence["container_side_effect_absent_on_client"] = True
+                evidence["non_json_stdout_ignored"] = True
+                invalid = Path(directory) / "invalid.py"
+                invalid.write_text(
+                    text + '\nLANGUAGES["go"]=replace(LANGUAGES["go"],file="../leibniz.go")\n'
+                )
+                try:
+                    await resolve_catalog(
+                        client, client.host().file(str(invalid)), source_revision=revision
+                    )
+                except ValueError as error:
+                    assert "relative POSIX" in str(error)
+                    evidence["exported_path_escape_rejected"] = True
+                else:
+                    raise AssertionError("Invalid source path was accepted")
+                assert not marker.exists()
+    finally:
+        os.environ.pop(environment_key, None)
+    return evidence
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    text = json.dumps(asyncio.run(check()), indent=2) + "\n"
+    if args.output:
+        args.output.write_text(text)
+    print(text, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/dagger-poc/test_catalog_manifest.py
+++ b/dagger-poc/test_catalog_manifest.py
@@ -164,3 +164,9 @@ def test_manifest_size_limit_precedes_json_parsing():
         load_manifest(
             " " * (MAX_MANIFEST_BYTES + 1), source_revision=REVISION, catalog_sha256=DIGEST
         )
+
+
+def test_base_image_identifier_cannot_escape_its_namespace(document):
+    document["languages"]["go"]["base"] = "../another-image"
+    with pytest.raises(ValueError, match="base-image identifier"):
+        load(document)

--- a/dagger-poc/test_catalog_manifest.py
+++ b/dagger-poc/test_catalog_manifest.py
@@ -170,3 +170,36 @@ def test_base_image_identifier_cannot_escape_its_namespace(document):
     document["languages"]["go"]["base"] = "../another-image"
     with pytest.raises(ValueError, match="base-image identifier"):
         load(document)
+
+
+def test_catalog_reader_accepts_only_regular_files_under_the_source_root(tmp_path):
+    from catalog_manifest import read_catalog_source
+
+    root = tmp_path / "source"
+    (root / "dagger-poc").mkdir(parents=True)
+    source = root / "dagger-poc/languages.py"
+    source.write_text("# catalog\n")
+    assert read_catalog_source(root, "dagger-poc/languages.py") == "# catalog\n"
+    with pytest.raises(ValueError):
+        read_catalog_source(root, "../outside.py")
+    with pytest.raises(ValueError):
+        read_catalog_source(root, "dagger-poc")
+    outside = tmp_path / "outside.py"
+    outside.write_text("private client data")
+    source.unlink()
+    source.symlink_to(outside)
+    with pytest.raises(ValueError, match="symlinks"):
+        read_catalog_source(root, "dagger-poc/languages.py")
+
+
+def test_catalog_reader_rejects_symlinked_parent_directories(tmp_path):
+    from catalog_manifest import read_catalog_source
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "languages.py").write_text("private client data")
+    root = tmp_path / "source"
+    root.mkdir()
+    (root / "dagger-poc").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError, match="symlinks"):
+        read_catalog_source(root, "dagger-poc/languages.py")

--- a/dagger-poc/test_catalog_manifest.py
+++ b/dagger-poc/test_catalog_manifest.py
@@ -1,0 +1,166 @@
+"""Validate the data boundary independently of the optional Dagger resolver."""
+
+import hashlib
+import json
+import subprocess
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+from catalog_manifest import MAX_MANIFEST_BYTES, load_manifest
+from languages import (
+    HYPERFINE_VERSION,
+    LANGUAGES,
+    MICROPYTHON_VERSION,
+    get_devbox_image,
+    language_image_fingerprint,
+)
+from result_metadata import methodology
+
+REVISION = "a" * 40
+DIGEST = hashlib.sha256(Path(__file__).with_name("languages.py").read_bytes()).hexdigest()
+
+
+@pytest.fixture
+def document():
+    return {
+        "schema_version": 1,
+        "source_revision": REVISION,
+        "catalog_sha256": DIGEST,
+        "tooling": {
+            "devbox_image": get_devbox_image(),
+            "hyperfine": HYPERFINE_VERSION,
+            "micropython": MICROPYTHON_VERSION,
+        },
+        "languages": {"go": asdict(LANGUAGES["go"])},
+    }
+
+
+def load(document):
+    return load_manifest(json.dumps(document), source_revision=REVISION, catalog_sha256=DIGEST)
+
+
+def test_all_targets_preserve_configuration_fingerprints_and_methodology(document):
+    document["languages"] = {target: asdict(lang) for target, lang in LANGUAGES.items()}
+    resolved = load(document)
+    assert resolved.languages == LANGUAGES
+    assert resolved.tooling == document["tooling"]
+    for target, lang in resolved.languages.items():
+        assert language_image_fingerprint(lang) == language_image_fingerprint(LANGUAGES[target])
+        assert methodology(target, lang) == methodology(target, LANGUAGES[target])
+
+
+def test_exporter_round_trip_for_trusted_source(tmp_path):
+    output = tmp_path / "catalog.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            str(Path(__file__).with_name("catalog_export.py")),
+            "--catalog",
+            str(Path(__file__).with_name("languages.py")),
+            "--revision",
+            REVISION,
+            "--output",
+            str(output),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    resolved = load_manifest(output.read_text(), source_revision=REVISION, catalog_sha256=DIGEST)
+    assert resolved.languages == LANGUAGES
+
+
+@pytest.mark.parametrize("key,value", [("source_revision", "b" * 40), ("catalog_sha256", "0" * 64)])
+def test_identity_mismatch_is_rejected(document, key, value):
+    document[key] = value
+    with pytest.raises(ValueError, match="identity"):
+        load(document)
+
+
+@pytest.mark.parametrize("value", [True, 2, "1"])
+def test_schema_version_is_strict(document, value):
+    document["schema_version"] = value
+    with pytest.raises(ValueError, match="schema version"):
+        load(document)
+
+
+def test_duplicate_keys_are_rejected(document):
+    payload = json.dumps(document).replace(
+        '"schema_version": 1', '"schema_version": 1, "schema_version": 1'
+    )
+    with pytest.raises(ValueError, match="Duplicate"):
+        load_manifest(payload, source_revision=REVISION, catalog_sha256=DIGEST)
+
+
+@pytest.mark.parametrize("scope", ["root", "tooling", "language"])
+def test_unknown_fields_are_rejected(document, scope):
+    value = {
+        "root": document,
+        "tooling": document["tooling"],
+        "language": document["languages"]["go"],
+    }[scope]
+    value["unknown"] = "unexpected"
+    with pytest.raises(ValueError, match="expected exactly"):
+        load(document)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/tmp/leibniz.go",
+        "../leibniz.go",
+        "dir/../../leibniz.go",
+        "dir//leibniz.go",
+        "dir/./leibniz.go",
+        "dir\\leibniz.go",
+        ".",
+    ],
+)
+def test_source_path_escape_and_ambiguity_are_rejected(document, path):
+    document["languages"]["go"]["file"] = path
+    with pytest.raises(ValueError, match="relative POSIX"):
+        load(document)
+
+
+def test_extra_file_path_escape_is_rejected(document):
+    document["languages"]["go"]["extra_files"] = ["../secret"]
+    with pytest.raises(ValueError, match="relative POSIX"):
+        load(document)
+
+
+@pytest.mark.parametrize(
+    "packages", [["go@latest"], ["go;echo bad@1.2"], ["go@1.2 --flag"], "go@1.2"]
+)
+def test_packages_cannot_smuggle_flags_or_unpinned_versions(document, packages):
+    document["languages"]["go"]["nixpkgs"] = packages
+    with pytest.raises(ValueError):
+        load(document)
+
+
+def test_moving_tooling_image_is_rejected(document):
+    document["tooling"]["devbox_image"] = "jetpackio/devbox:latest"
+    with pytest.raises(ValueError, match="pinned digest"):
+        load(document)
+
+
+def test_moving_flake_is_rejected(document):
+    document["languages"]["go"]["nix_flakes"] = ["github:NixOS/nixpkgs/master#go"]
+    with pytest.raises(ValueError, match="immutable"):
+        load(document)
+
+
+def test_commands_remain_data(document, tmp_path):
+    marker = tmp_path / "executed"
+    document["languages"]["go"]["run"] = f"touch {marker}"
+    assert load(document).languages["go"].run == f"touch {marker}"
+    assert not marker.exists()
+
+
+def test_manifest_size_limit_precedes_json_parsing():
+    with pytest.raises(ValueError, match="size limit"):
+        load_manifest(
+            " " * (MAX_MANIFEST_BYTES + 1), source_revision=REVISION, catalog_sha256=DIGEST
+        )

--- a/docs/catalog-resolution.md
+++ b/docs/catalog-resolution.md
@@ -18,6 +18,10 @@ mode, a 30-second export-process limit and a 120-second operation deadline. It d
 not mount a host directory, Docker socket, caller environment or secret into the
 export container. Python source is evaluated there; the calling process reads the
 output file as data. Catalog stdout is not used as the JSON transport.
+Both uppercase and lowercase standard proxy variables are explicitly set empty
+before execution: Dagger otherwise inherits proxy settings from its engine, which
+may include credentials. Explicit values suppress that inheritance in
+[Dagger 0.19.8](https://github.com/dagger/dagger/blob/v0.19.8/engine/buildkit/executor_spec.go#L851).
 
 `catalog_manifest.py` checks the returned identity against the caller's source SHA
 and the independently computed hash of the supplied catalog. It rejects duplicate
@@ -65,7 +69,10 @@ math/SIMD labels, plus invalid identities, schemas, paths and pins. It does not 
 Docker. The optional real-Dagger check verifies the full catalog and uses an authored
 fixture with a file side effect, client-environment probe and non-JSON stdout. It
 checks that the side effect stays off the client filesystem, the client value is not
-forwarded, and invalid exported paths are rejected. This exercises the implemented
+forwarded, and invalid exported paths are rejected. A second container starts with
+fake credentialed proxy values and verifies that the resolver clears every standard
+proxy variable. This checks explicit overrides without modifying the shared engine's
+configuration; it does not simulate a separately configured proxy engine. This exercises the implemented
 boundary; it does not validate the future homelab deployment or run any benchmarks.
 
 The [recorded integration evidence](validation/2026-09-05-catalog-resolution.json)

--- a/docs/catalog-resolution.md
+++ b/docs/catalog-resolution.md
@@ -8,6 +8,10 @@ automatic dispatch and the isolated persistent homelab engine remain rollout gat
 
 ## Boundary and identity
 
+The local CLI reads a regular UTF-8 file beneath an explicit source root. Directory
+handles and no-follow opens reject symlinked files/parents before uploading data,
+including links that could otherwise expose files outside an unreviewed checkout.
+
 `catalog_resolver.py` uploads only the requested catalog file and the trusted
 `catalog_export.py` helper. It uses a digest-pinned Python 3.12 image, Python isolated
 mode, a 30-second export-process limit and a 120-second operation deadline. It does
@@ -47,7 +51,8 @@ From a trusted checkout, with an existing local Dagger-compatible runtime:
 
 ```sh
 uv run --locked --project dagger-poc python dagger-poc/catalog_resolver.py \
-  --catalog /path/to/verified-source/dagger-poc/languages.py \
+  --source-root /path/to/verified-source \
+  --catalog dagger-poc/languages.py \
   --source-revision FULL_VERIFIED_COMMIT_SHA \
   --output /tmp/catalog.json
 
@@ -65,4 +70,4 @@ boundary; it does not validate the future homelab deployment or run any benchmar
 
 The [recorded integration evidence](validation/2026-09-05-catalog-resolution.json)
 includes the source/catalog identity, driver hashes, resolver image, SDK version
-and observed checks. The complete Python suite has 127 passing tests.
+and observed checks. The complete Python suite has 129 passing tests.

--- a/docs/catalog-resolution.md
+++ b/docs/catalog-resolution.md
@@ -27,6 +27,7 @@ tooling and all normalized language definitions. It is **not an authorization to
 or proof that an arbitrary checkout matches its declared revision. The dispatcher
 must verify the exact commit snapshot, authorize that head revision, recompute the
 affected-target plan and retain the resolved manifest with the run evidence.
+Execution order belongs to the authorized run plan, not JSON object-key order.
 A Python catalog can be dynamic; recording only its source hash is insufficient.
 
 Use the driver and its dependencies from a trusted checkout, with the proposed
@@ -64,4 +65,4 @@ boundary; it does not validate the future homelab deployment or run any benchmar
 
 The [recorded integration evidence](validation/2026-09-05-catalog-resolution.json)
 includes the source/catalog identity, driver hashes, resolver image, SDK version
-and observed checks. The complete Python suite has 126 passing tests.
+and observed checks. The complete Python suite has 127 passing tests.

--- a/docs/catalog-resolution.md
+++ b/docs/catalog-resolution.md
@@ -1,0 +1,67 @@
+# Resolving language declarations
+
+Contributors keep editing `dagger-poc/languages.py`. A trusted driver can now resolve
+that Python file inside a Dagger container and consume a validated JSON manifest.
+There is no second manually maintained catalog and no change to the current
+benchmark execution path. This is preparation for authorized selective PR execution;
+automatic dispatch and the isolated persistent homelab engine remain rollout gates.
+
+## Boundary and identity
+
+`catalog_resolver.py` uploads only the requested catalog file and the trusted
+`catalog_export.py` helper. It uses a digest-pinned Python 3.12 image, Python isolated
+mode, a 30-second export-process limit and a 120-second operation deadline. It does
+not mount a host directory, Docker socket, caller environment or secret into the
+export container. Python source is evaluated there; the calling process reads the
+output file as data. Catalog stdout is not used as the JSON transport.
+
+`catalog_manifest.py` checks the returned identity against the caller's source SHA
+and the independently computed hash of the supplied catalog. It rejects duplicate
+JSON keys, unknown/missing fields, unsupported schemas, incorrect types, path
+traversal, unpinned tooling and malformed package arguments. Source and output sizes
+are limited to 4 MiB, with at most 512 targets. It reconstructs the trusted driver's
+`Language` objects, preserving every field, compiler command and shared value.
+
+The manifest contains a schema version, source revision, catalog SHA-256, resolved
+tooling and all normalized language definitions. It is **not an authorization token**
+or proof that an arbitrary checkout matches its declared revision. The dispatcher
+must verify the exact commit snapshot, authorize that head revision, recompute the
+affected-target plan and retain the resolved manifest with the run evidence.
+A Python catalog can be dynamic; recording only its source hash is insufficient.
+
+Use the driver and its dependencies from a trusted checkout, with the proposed
+catalog supplied as a separate input file. Running a PR's replacement resolver on
+a credentialed client would defeat this boundary. The current resolver supports the
+single catalog file's standard-library imports, as used by all existing definitions;
+additional local helper modules would require an explicit input contract.
+
+Commands in the manifest remain executable build/run instructions for the isolated
+engine. The engine isolation and revision-authorization requirements still apply.
+The benchmark runner is not yet wired to consume this manifest, so tooling overrides
+and selected-source binding must be implemented before that cutover.
+
+## Local use and checks
+
+From a trusted checkout, with an existing local Dagger-compatible runtime:
+
+```sh
+uv run --locked --project dagger-poc python dagger-poc/catalog_resolver.py \
+  --catalog /path/to/verified-source/dagger-poc/languages.py \
+  --source-revision FULL_VERIFIED_COMMIT_SHA \
+  --output /tmp/catalog.json
+
+uv run --locked --project dagger-poc --extra dev pytest dagger-poc -q
+uv run --locked --project dagger-poc python dagger-poc/check_catalog_resolver.py
+```
+
+The unit suite checks lossless parity for all 75 targets, image fingerprints and
+math/SIMD labels, plus invalid identities, schemas, paths and pins. It does not need
+Docker. The optional real-Dagger check verifies the full catalog and uses an authored
+fixture with a file side effect, client-environment probe and non-JSON stdout. It
+checks that the side effect stays off the client filesystem, the client value is not
+forwarded, and invalid exported paths are rejected. This exercises the implemented
+boundary; it does not validate the future homelab deployment or run any benchmarks.
+
+The [recorded integration evidence](validation/2026-09-05-catalog-resolution.json)
+includes the source/catalog identity, driver hashes, resolver image, SDK version
+and observed checks. The complete Python suite has 126 passing tests.

--- a/docs/nix-migration.md
+++ b/docs/nix-migration.md
@@ -77,7 +77,7 @@ The first Argo workflow `speed-comparison-manual-vmv76` passed checkout, native
 Python execution, S3 upload, and analysis. Its combined archive was downloaded
 to verify retrieval. Local Dagger Python execution also passed after changing
 both adapters to use command files, preserving shell variable expansion.
-The current Python regression suite has 99 passing tests. Two fresh Dagger runs
+The current Python regression suite has 129 passing tests. Two fresh Dagger runs
 verified build-cache reuse without reusing timing results.
 
 Homelab PRs [#34](https://github.com/niklas-heer/homelab/pull/34) and

--- a/docs/pipeline-architecture.md
+++ b/docs/pipeline-architecture.md
@@ -148,7 +148,7 @@ pod. This is a material preparation problem, independent of Python SDK overhead.
 The shared five-execution protocol and Dagger cache boundary are implemented.
 Two real local Dagger runs reused build layers and produced distinct fresh
 sample arrays/measurement IDs. The Python suite, including target-selection and
-measurement protocol tests, has 127 passing cases at this design revision.
+measurement protocol tests, has 129 passing cases at this design revision.
 
 ## Results, database and website
 

--- a/docs/pipeline-architecture.md
+++ b/docs/pipeline-architecture.md
@@ -148,7 +148,7 @@ pod. This is a material preparation problem, independent of Python SDK overhead.
 The shared five-execution protocol and Dagger cache boundary are implemented.
 Two real local Dagger runs reused build layers and produced distinct fresh
 sample arrays/measurement IDs. The Python suite, including target-selection and
-measurement protocol tests, has 126 passing cases at this design revision.
+measurement protocol tests, has 127 passing cases at this design revision.
 
 ## Results, database and website
 

--- a/docs/pipeline-architecture.md
+++ b/docs/pipeline-architecture.md
@@ -79,7 +79,10 @@ for dispatch and status. Keep publishing/database credentials out of test execut
 Fork PR execution must be explicitly authorized for its current head revision, and
 the driver itself must come from trusted code. Do not run a PR's replacement runner
 on a credentialed Argo client. Source and declarative configuration can be evaluated
-inside the isolated execution boundary. Superseded queued PR revisions can be
+inside the isolated execution boundary. The [catalog resolver](catalog-resolution.md)
+now provides a tested Python-to-JSON boundary through Dagger, preserving the current
+authoring format. Wiring its output into benchmark execution and trusted dispatch
+remains a separate step. Superseded queued PR revisions can be
 cancelled; preserve completed evidence.
 
 ## Choose workload sizes from evidence
@@ -145,7 +148,7 @@ pod. This is a material preparation problem, independent of Python SDK overhead.
 The shared five-execution protocol and Dagger cache boundary are implemented.
 Two real local Dagger runs reused build layers and produced distinct fresh
 sample arrays/measurement IDs. The Python suite, including target-selection and
-measurement protocol tests, has 99 passing cases at this design revision.
+measurement protocol tests, has 126 passing cases at this design revision.
 
 ## Results, database and website
 

--- a/docs/validation/2026-09-05-catalog-resolution.json
+++ b/docs/validation/2026-09-05-catalog-resolution.json
@@ -1,5 +1,5 @@
 {
-  "source_revision": "5592718a2956dd460a7e7b5ca7699c14a78ef641",
+  "source_revision": "e3c80348b89925e70be604f33bca998368133ba4",
   "resolver_image": "python:3.12-slim@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea",
   "dagger_sdk": "0.19.8",
   "targets_round_tripped": 75,
@@ -9,14 +9,16 @@
   "non_json_stdout_ignored": true,
   "exported_path_escape_rejected": true,
   "scope": "Catalog resolution only; no benchmarks or homelab deployment",
-  "checked_at": "2026-09-05T21:40:49.493920+00:00",
+  "checked_at": "2026-09-05T21:47:31.099714+00:00",
   "client_platform": "Darwin arm64",
   "driver_files_sha256": {
     "catalog_export.py": "6f3b9ca6955cb5c04ac261d990e760fc3e54c80d1476f26116a2f3be7766a5d9",
     "catalog_manifest.py": "ecfa174ea035c207cd2295aff4a84f73a17f8783abf734dbe0733eef7e5cb09f",
-    "catalog_resolver.py": "c01beba6dd8983788d0324da8cdad700132d0320dcd5c82367e4ce6f95cffe18",
-    "check_catalog_resolver.py": "afe315e788121169ee16d7f6d14b311e28c2ab17597011755331ecf66ddfc372"
+    "catalog_resolver.py": "729a44a6d22c1a12f4e5317d59058de11608a997bf9aa18560f397f922bc3b91",
+    "check_catalog_resolver.py": "e08870e1adc9fe07265ab3fcd74a8aa1dafef49ebd8601478fd78690514b9ac7"
   },
   "local_cli_regular_file_check_passed": true,
-  "unit_tests_passed": 129
+  "unit_tests_passed": 129,
+  "explicit_fake_proxy_credentials_cleared": true,
+  "standard_proxy_environment_empty": true
 }

--- a/docs/validation/2026-09-05-catalog-resolution.json
+++ b/docs/validation/2026-09-05-catalog-resolution.json
@@ -1,5 +1,5 @@
 {
-  "source_revision": "06ea3fd9de709cfb7ea6b706c2ba81ad82a0363e",
+  "source_revision": "5592718a2956dd460a7e7b5ca7699c14a78ef641",
   "resolver_image": "python:3.12-slim@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea",
   "dagger_sdk": "0.19.8",
   "targets_round_tripped": 75,
@@ -9,12 +9,14 @@
   "non_json_stdout_ignored": true,
   "exported_path_escape_rejected": true,
   "scope": "Catalog resolution only; no benchmarks or homelab deployment",
-  "checked_at": "2026-09-05T21:30:47.466055+00:00",
+  "checked_at": "2026-09-05T21:40:49.493920+00:00",
   "client_platform": "Darwin arm64",
   "driver_files_sha256": {
     "catalog_export.py": "6f3b9ca6955cb5c04ac261d990e760fc3e54c80d1476f26116a2f3be7766a5d9",
-    "catalog_manifest.py": "a17b1e4937a2cf335f66df88c70c1ca7c41ba53aed4e1fde03dc099e103dd906",
-    "catalog_resolver.py": "c45e13a3d989651c7d04f7c8420d7a65305d6c77ad2b4d95f390210f456a13f8",
+    "catalog_manifest.py": "ecfa174ea035c207cd2295aff4a84f73a17f8783abf734dbe0733eef7e5cb09f",
+    "catalog_resolver.py": "c01beba6dd8983788d0324da8cdad700132d0320dcd5c82367e4ce6f95cffe18",
     "check_catalog_resolver.py": "afe315e788121169ee16d7f6d14b311e28c2ab17597011755331ecf66ddfc372"
-  }
+  },
+  "local_cli_regular_file_check_passed": true,
+  "unit_tests_passed": 129
 }

--- a/docs/validation/2026-09-05-catalog-resolution.json
+++ b/docs/validation/2026-09-05-catalog-resolution.json
@@ -1,0 +1,20 @@
+{
+  "source_revision": "6e4825ba8e4519659806306afdf32f5bfb996db9",
+  "resolver_image": "python:3.12-slim@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea",
+  "dagger_sdk": "0.19.8",
+  "targets_round_tripped": 75,
+  "catalog_sha256": "59ccadb60731358a040df3f2405c1a72658ca1eb7bd2d7cbed361f48fa7598c9",
+  "client_environment_not_forwarded": true,
+  "container_side_effect_absent_on_client": true,
+  "non_json_stdout_ignored": true,
+  "exported_path_escape_rejected": true,
+  "scope": "Catalog resolution only; no benchmarks or homelab deployment",
+  "checked_at": "2026-09-05T21:28:24.124124+00:00",
+  "client_platform": "Darwin arm64",
+  "driver_files_sha256": {
+    "catalog_export.py": "6f3b9ca6955cb5c04ac261d990e760fc3e54c80d1476f26116a2f3be7766a5d9",
+    "catalog_manifest.py": "44337a75044265af34843ed64d51bb10ea2b1551f30fb0e0760c091b4af994d5",
+    "catalog_resolver.py": "c45e13a3d989651c7d04f7c8420d7a65305d6c77ad2b4d95f390210f456a13f8",
+    "check_catalog_resolver.py": "afe315e788121169ee16d7f6d14b311e28c2ab17597011755331ecf66ddfc372"
+  }
+}

--- a/docs/validation/2026-09-05-catalog-resolution.json
+++ b/docs/validation/2026-09-05-catalog-resolution.json
@@ -1,5 +1,5 @@
 {
-  "source_revision": "6e4825ba8e4519659806306afdf32f5bfb996db9",
+  "source_revision": "06ea3fd9de709cfb7ea6b706c2ba81ad82a0363e",
   "resolver_image": "python:3.12-slim@sha256:78387bc3881b8273120a12ebe6c1ab22b018ccc2c9adf565ae1ac9b536e184ea",
   "dagger_sdk": "0.19.8",
   "targets_round_tripped": 75,
@@ -9,11 +9,11 @@
   "non_json_stdout_ignored": true,
   "exported_path_escape_rejected": true,
   "scope": "Catalog resolution only; no benchmarks or homelab deployment",
-  "checked_at": "2026-09-05T21:28:24.124124+00:00",
+  "checked_at": "2026-09-05T21:30:47.466055+00:00",
   "client_platform": "Darwin arm64",
   "driver_files_sha256": {
     "catalog_export.py": "6f3b9ca6955cb5c04ac261d990e760fc3e54c80d1476f26116a2f3be7766a5d9",
-    "catalog_manifest.py": "44337a75044265af34843ed64d51bb10ea2b1551f30fb0e0760c091b4af994d5",
+    "catalog_manifest.py": "a17b1e4937a2cf335f66df88c70c1ca7c41ba53aed4e1fde03dc099e103dd906",
     "catalog_resolver.py": "c45e13a3d989651c7d04f7c8420d7a65305d6c77ad2b4d95f390210f456a13f8",
     "check_catalog_resolver.py": "afe315e788121169ee16d7f6d14b311e28c2ab17597011755331ecf66ddfc372"
   }


### PR DESCRIPTION
Selective PR execution needs a way to resolve the existing Python language declarations without importing the proposed catalog into a credentialed client. This adds an optional Dagger resolver and strict manifest model while preserving Python as the authoring source.

The trusted driver supplies its own exporter and only the input catalog file to a digest-pinned Python container. The local CLI uses bounded, no-follow file reads beneath an explicit source root, rejecting symlinked catalog files and parent directories before upload. The returned JSON is checked against the independently computed catalog hash and caller-owned source revision, with strict schemas, duplicate-key rejection, bounded sizes, canonical source paths and pinned tooling. Explicit empty upper/lowercase proxy variables suppress engine proxy inheritance before execution. All 75 language configurations, image fingerprints and math/SIMD labels round-trip without loss.

The resolver is a prerequisite, not automatic PR dispatch or a replacement execution adapter. Verified commit snapshots, revision authorization, isolated homelab deployment and wiring all resolved tooling into benchmark execution remain explicit rollout gates. The manifest is not an authorization token.

Validation: 129 unit tests pass; focused full Ruff checks pass. Real Dagger 0.19.8 checks resolve all 75 targets, keep an authored catalog file side effect off the client filesystem, do not forward the test client environment value, tolerate non-JSON catalog stdout and reject an exported path escape. A real-container proxy regression confirms fake credentialed settings are present before clearing and absent during catalog execution; the shared engine is unchanged. Evidence records source/catalog identity, driver hashes, resolver image and SDK version. No benchmarks were run and no homelab settings were changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional catalog resolution workflow that exports validated catalog data without changing active benchmark execution or enabling automatic dispatch.
  - Added safeguards for source integrity, schema validation, file boundaries, payload limits, pinned tooling, and proxy credential isolation.

- **Documentation**
  - Documented catalog resolution, its security behavior, and its separation from benchmark execution and trusted dispatch.
  - Updated validation records and test-count references.

- **Tests**
  - Added coverage for manifest validation, path safety, isolation, proxy handling, malformed output, and catalog parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->