### PR TITLE
Address remaining CI, Hare and historical-evidence review comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,6 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
-            BASE_SHA=$(git rev-parse "$HEAD_SHA^")
-          fi
           python scripts/affected_targets.py --base "$BASE_SHA" --head "$HEAD_SHA" --output benchmark-plan.json
           python - <<'PY'
           import json, os

--- a/dagger-poc/test_affected_targets.py
+++ b/dagger-poc/test_affected_targets.py
@@ -94,3 +94,41 @@ def test_execution_lock_still_selects_all_targets():
     plan = affected(CATALOG, CATALOG, ['dagger-poc/uv.lock'])
     assert len(plan['targets']) == 4
     assert plan['report_check'] is False
+
+
+def test_revision_planning_handles_missing_history(tmp_path, monkeypatch):
+    import subprocess
+    from affected_targets import plan_revisions
+
+    def git(*args):
+        return subprocess.check_output(['git', *args], cwd=tmp_path, text=True).strip()
+
+    git('init', '-q')
+    git('config', 'user.name', 'Planner Test')
+    git('config', 'user.email', 'planner@example.invalid')
+    (tmp_path / 'dagger-poc').mkdir()
+    (tmp_path / 'dagger-poc/languages.py').write_text(CATALOG)
+    git('add', '.')
+    git('commit', '-qm', 'Initial catalog')
+    first = git('rev-parse', 'HEAD')
+    monkeypatch.chdir(tmp_path)
+    for base in ('', '0' * 40, 'f' * 40):
+        plan = plan_revisions(base, first)
+        assert plan['targets'] == ['c', 'c-clang', 'fs', 'swift']
+        assert plan['report_check'] is True
+        assert plan['base_revision'] is None
+        assert plan['head_revision'] == first
+        assert plan['requested_base_revision'] == base
+        assert plan['publication_eligible'] is False
+        assert 'full validation' in plan['fallback_reason']
+    (tmp_path / 'src').mkdir()
+    (tmp_path / 'src/leibniz.c').write_text('/* changed */')
+    git('add', '.')
+    git('commit', '-qm', 'C source')
+    selective = plan_revisions(first, 'HEAD')
+    assert selective['targets'] == ['c', 'c-clang']
+    assert selective['report_check'] is False
+    git('checkout', '--orphan', 'unrelated')
+    git('commit', '-qm', 'Unrelated catalog')
+    assert plan_revisions(first, 'HEAD')['base_revision'] is None
+    assert len(plan_revisions(first, 'HEAD')['targets']) == 4

--- a/docs/nix-migration.md
+++ b/docs/nix-migration.md
@@ -77,7 +77,7 @@ The first Argo workflow `speed-comparison-manual-vmv76` passed checkout, native
 Python execution, S3 upload, and analysis. Its combined archive was downloaded
 to verify retrieval. Local Dagger Python execution also passed after changing
 both adapters to use command files, preserving shell variable expansion.
-The current Python regression suite has 129 passing tests. Two fresh Dagger runs
+The current Python regression suite has 130 passing tests. Two fresh Dagger runs
 verified build-cache reuse without reusing timing results.
 
 Homelab PRs [#34](https://github.com/niklas-heer/homelab/pull/34) and
@@ -95,6 +95,8 @@ records source `c71e4cd81464b238172605982806c5bf827a70a1`, compiler flags,
 math/SIMD labels and resolved environments. The [raw target files](history/2026-09-05T193245/raw/README.md)
 preserve the original samples and file hashes independently of Argo retention. Source-linked publication commit:
 `151d287536218d2320a45dacf18c692fea4db2c2`.
+The measured source and subsequent publication commit are intentionally distinct:
+publishing archived artifacts creates a new commit, without changing what was run.
 
 The baseline is validation evidence, not the permanent execution architecture.
 [The pipeline design](pipeline-architecture.md) keeps Python declarations and uses

--- a/docs/pipeline-architecture.md
+++ b/docs/pipeline-architecture.md
@@ -148,7 +148,7 @@ pod. This is a material preparation problem, independent of Python SDK overhead.
 The shared five-execution protocol and Dagger cache boundary are implemented.
 Two real local Dagger runs reused build layers and produced distinct fresh
 sample arrays/measurement IDs. The Python suite, including target-selection and
-measurement protocol tests, has 129 passing cases at this design revision.
+measurement protocol tests, has 130 passing cases at this design revision.
 
 ## Results, database and website
 
@@ -204,7 +204,11 @@ Do not automatically enable the native weekly full-suite schedule simply because
 migration baseline finishes. The maintainer's clarified architecture and calibration
 requirements supersede that earlier rollout gate.
 
-References: [Dagger on Kubernetes](https://docs.dagger.io/reference/deployment/kubernetes/),
-[Dagger engine requirements](https://docs.dagger.io/0.20/reference/configuration/engine/),
+References: [Dagger Kubernetes guidance (newer release)](https://docs.dagger.io/reference/deployment/kubernetes/),
+[Dagger engine requirements](https://docs.dagger.io/0.19/reference/configuration/engine/),
 [Hyperfine timing and warmup behavior](https://github.com/sharkdp/hyperfine), and
 [pyperf guidance on assessing unstable results](https://pyperf.readthedocs.io/en/latest/analyze.html).
+
+The Kubernetes deployment page tracks newer Dagger releases; it is forward-looking
+guidance, not a validated deployment recipe for the tested 0.19.8 engine. The engine
+configuration reference is pinned to the 0.19 documentation series.

--- a/docs/validation/2026-09-05-ocaml-control/README.md
+++ b/docs/validation/2026-09-05-ocaml-control/README.md
@@ -4,6 +4,9 @@ Both runs used source `c71e4cd81464b238172605982806c5bf827a70a1`, one billion
 rounds and the same homelab worker (`slick-badger`, virtualized AMD EPYC-Genoa,
 Talos kernel 6.18.38). GCC was 15.2.0 and OCaml 5.3.0. Each target had two warmups,
 three measured executions and a separate output execution. Timing was serial.
+This historical six-execution protocol belongs to the recorded source revision;
+the five-execution protocol introduced later in #316 does not retroactively change
+these measurements.
 
 | Configuration | Median seconds | Math policy |
 | --- | ---: | --- |

--- a/scripts/affected_targets.py
+++ b/scripts/affected_targets.py
@@ -127,19 +127,32 @@ def git(*args: str, required: bool = True) -> str | None:
     return result.stdout
 
 
+def plan_revisions(base_ref: str, head_ref: str) -> dict:
+    head = git('rev-parse', '--verify', '--end-of-options', head_ref + '^{commit}').strip()
+    base = git('rev-parse', '--verify', '--end-of-options', base_ref + '^{commit}', required=False) if base_ref else None
+    merge_base = git('merge-base', base.strip(), head, required=False) if base else None
+    if merge_base:
+        merge_base = merge_base.strip()
+        changes = git('diff', '--name-only', '--no-renames', '-z', merge_base, head).split('\0')
+        plan = affected(git('show', f'{merge_base}:{CATALOG}', required=False),
+                        git('show', f'{head}:{CATALOG}'), [p for p in changes if p])
+    else:
+        # A force push can make the previous commit unreachable even in a full
+        # checkout. Comparing only HEAD^ would silently miss earlier changes.
+        plan = affected(None, git('show', f'{head}:{CATALOG}'), [])
+        plan['report_check'] = True
+        plan['fallback_reason'] = 'Base commit unavailable or no common ancestor; full validation required'
+    plan.update(base_revision=merge_base, head_revision=head, requested_base_revision=base_ref)
+    return plan
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--base', required=True)
     parser.add_argument('--head', default='HEAD')
     parser.add_argument('--output', type=Path)
     args = parser.parse_args()
-    base = git('rev-parse', '--verify', '--end-of-options', args.base + '^{commit}').strip()
-    head = git('rev-parse', '--verify', '--end-of-options', args.head + '^{commit}').strip()
-    merge_base = git('merge-base', base, head).strip()
-    changes = git('diff', '--name-only', '--no-renames', '-z', merge_base, head).split('\0')
-    plan = affected(git('show', f'{merge_base}:{CATALOG}', required=False),
-                    git('show', f'{head}:{CATALOG}'), [p for p in changes if p])
-    plan.update(base_revision=merge_base, head_revision=head)
+    plan = plan_revisions(args.base, args.head)
     text = json.dumps(plan, indent=2) + '\n'
     if args.output:
         args.output.write_text(text)

--- a/src/leibniz.ha
+++ b/src/leibniz.ha
@@ -5,8 +5,9 @@ use strings;
 use strconv;
 
 export fn main() void = {
-       const rounds = os::open("rounds.txt")!;
-       const rounds = io::drain(rounds)!;
+       const input = os::open("rounds.txt")!;
+       defer io::close(input)!;
+       const rounds = io::drain(input)!;
        const rounds = strings::fromutf8(rounds)!;
        const rounds = strconv::stou32(strings::trim(rounds))!;
 


### PR DESCRIPTION
Force pushes can leave CI without its previous commit, causing target planning to fail or miss changes if it falls back to only HEAD's parent. The planner now selects every target and report validation when the base commit or common ancestor is unavailable, retaining the requested revision and fallback reason. Normal comparisons remain selective.

This also closes Hare's rounds-file handle and finishes the remaining documentation review from #304 and #316. Historical OCaml evidence retains its actual six-execution protocol and distinct measured-source/publication commits. Engine documentation is pinned to 0.19, and newer Kubernetes guidance is explicitly labelled.

Validation: all 130 Python tests pass, including a real temporary Git repository exercising missing/zero/empty bases, initial commits, unrelated history and normal selective changes. Undefined-name checks pass. Hare 0.26.0 builds through the existing local Dagger engine and matches expected output for 7 and 1,000 rounds. No published benchmark measurements were replaced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Validation now safely falls back to full validation when revision history is unavailable or cannot be compared.
  - Improved handling of input files to ensure resources are closed correctly.

- **Documentation**
  - Updated documentation to reflect the latest regression-test count.
  - Clarified benchmark and publication revisions, execution protocols, and supported pipeline references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->