### PR TITLE
Fix checkpoint identity and historical timing review findings

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,10 +1,10 @@
 name: Website
 on:
   pull_request:
-    paths: ['site/**', 'docs/history/**', 'vercel.json', '.github/workflows/site.yml']
+    paths: ['site/**', 'docs/history/**', 'vercel.json', '.vercelignore', '.github/workflows/site.yml']
   push:
     branches: [master]
-    paths: ['site/**', 'docs/history/**', 'vercel.json', '.github/workflows/site.yml']
+    paths: ['site/**', 'docs/history/**', 'vercel.json', '.vercelignore', '.github/workflows/site.yml']
   workflow_dispatch:
 permissions:
   contents: read

--- a/dagger-poc/test_weekly_plan.py
+++ b/dagger-poc/test_weekly_plan.py
@@ -82,3 +82,10 @@ def test_reverted_history_compares_published_tree_not_merge_base(repo):
     (root / "src/go.go").write_text("measured change")
     checkpoint["source_revision"] = commit()
     assert plan(checkpoint, base, ENV)["run_full_suite"]
+
+
+@pytest.mark.parametrize("source", ["HEAD", "master", "", "abc123", None, 123])
+def test_checkpoint_rejects_moving_refs_and_invalid_source_ids(repo, source):
+    *_, checkpoint = repo
+    with pytest.raises(ValueError, match="immutable source revision"):
+        plan({**checkpoint, "source_revision": source}, "HEAD", ENV)

--- a/docs/pipeline-architecture.md
+++ b/docs/pipeline-architecture.md
@@ -19,8 +19,9 @@ flowchart LR
     Dagger --> Cache[Persistent Nix and build cache]
     Dagger --> Samples[Fresh benchmark samples]
     Samples --> S3[Immutable result bundles in object storage]
-    S3 --> Index[Private Postgres run index]
-    Index --> Astro[Astro static build and browser checks]
+    S3 --> Published[Validated published Git snapshot]
+    Published --> Index[Private Postgres archive and run index]
+    Published --> Astro[Astro static build and browser checks]
     Astro --> Site[Public static site and downloadable data]
 ```
 

--- a/docs/pipeline-consolidation.md
+++ b/docs/pipeline-consolidation.md
@@ -18,7 +18,7 @@ estimate, not measured workflow elapsed time:
 | Remaining 70 targets | 303.50 s | 18.0% |
 
 The five slowest targets account for 82% of this execution estimate. Even with
-zero setup overhead, the current five-execution protocol would project about
+zero setup overhead, the previous five-execution protocol would project about
 140 minutes at that workload, assuming similar durations. Caching cannot remove
 that computation. Conversely, the native run installed environments separately
 in disposable pods: C's roughly one second of executions occupied a 70-second
@@ -114,11 +114,12 @@ uv run --locked python analyze.py --folder /path/to/run/targets \
 
 This is local analysis, not authorization to promote a quick/subset report as latest.
 
-Postgres can later index those bundles, and Astro can provide workload selectors,
-methodology filters and history. Neither should become a dependency of benchmark
-execution. A website change must not run benchmarks. Implement indexing and the
-Astro view only after the common runner, event integration and calibrated profile
-are working; the existing report/history remains available throughout.
+The Astro report is now live on Vercel, building directly from committed published
+snapshots. A separate daily Argo job archives those same snapshots in private
+Postgres. Neither website builds nor archive retries repeat benchmarks. The
+maintainer requested this presentation/archive work while isolated runner selection
+remains pending; it does not replace the remaining Dagger dispatch/reporting gates.
+See [website operations](../site/README.md) for the independent build and importer.
 
 ## Current proof and next acceptance gates
 
@@ -143,7 +144,8 @@ Remaining acceptance gates, in order:
 3. Connect revision-specific PR authorization and GitHub checks. Demonstrate one Go
    change selecting only its dependent targets and a docs change selecting none.
 4. Validate/version the common reporting workload, then enable its schedule.
-5. Add the independent result index and Astro presentation, preserving history.
+The independent Postgres index and Astro presentation are complete: 110 historical
+snapshots remain available, with 75 detailed targets in the latest baseline.
 
 The manual commit entry point is not automatic PR authorization. Run the driver
 from reviewed code; never dispatch an unreviewed replacement driver with client
@@ -175,7 +177,7 @@ runner checkpoint. The Argo adapter must supply and verify this identity and hol
 a global runner mutex; this CLI alone does not enable the suspended schedule.
 
 Vercel builds the separate Astro site from immutable published snapshots. The
-optional homelab Postgres archive indexes those snapshots for queries without
+homelab Postgres archive indexes those snapshots for queries without
 putting a database request in the public page path. Publication, archive import
 and website deployment can each be retried without repeating measurements.
 

--- a/scripts/weekly_plan.py
+++ b/scripts/weekly_plan.py
@@ -37,6 +37,10 @@ def plan(checkpoint: dict | None, head_ref: str, environment: dict) -> dict:
         checkpoint.get("schema_version") != 1 or checkpoint.get("status") != "published"
     ):
         raise ValueError("Checkpoint must identify a successful published run")
+    if checkpoint and (
+        not isinstance(base, str) or not re.fullmatch(r"[0-9a-f]{40}", base)
+    ):
+        raise ValueError("Checkpoint must identify an immutable source revision")
     base_commit = (
         git(
             "rev-parse",

--- a/site/src/lib/results.mjs
+++ b/site/src/lib/results.mjs
@@ -21,6 +21,11 @@ export function timing(n) {
     ? `${(n * 1000).toFixed(2)} ms`
     : `${n.toFixed(n < 10 ? 3 : 2)} s`;
 }
+export function recordedTiming(value) {
+  return value === undefined || value === null || value === ""
+    ? "Not recorded"
+    : timing(seconds(value));
+}
 export function runData(id) {
   const dir = path.join(historyDir, validId(id));
   const file = path.join(dir, "combined_results.json");

--- a/site/src/pages/results/[run]/[target].astro
+++ b/site/src/pages/results/[run]/[target].astro
@@ -2,7 +2,7 @@
 import Layout from "../../../layouts/Layout.astro";
 import Metadata from "../../../components/Metadata.astro";
 import Package from "../../../components/Package.astro";
-import { runs, runData, timing, repo } from "../../../lib/results.mjs";
+import { runs, runData, timing, recordedTiming, repo } from "../../../lib/results.mjs";
 export function getStaticPaths() {
   return runs.flatMap((run) => {
     const data = runData(run.id);
@@ -60,12 +60,12 @@ const known = new Set(["DevboxLock", "Environment", "DevboxConfig"]);
     </div><div>
       <span class="eyebrow">Fastest sample</span><strong
         >{
-          raw ? timing(Number(raw.Min.replace("s", ""))) : "Not recorded"
+          recordedTiming(raw?.Min)
         }</strong>
     </div><div>
       <span class="eyebrow">Slowest sample</span><strong
         >{
-          raw ? timing(Number(raw.Max.replace("s", ""))) : "Not recorded"
+          recordedTiming(raw?.Max)
         }</strong>
     </div><div>
       <span class="eyebrow">Samples retained</span><strong

--- a/site/tests/archive.test.mjs
+++ b/site/tests/archive.test.mjs
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { snapshot, importSnapshot } from "../scripts/archive.mjs";
 test("archive covers original files and rejects conflicting snapshots atomically", async () => {
   const entry = snapshot("2026-09-05T193245");
@@ -22,4 +23,20 @@ test("archive covers original files and rejects conflicting snapshots atomically
   );
   assert.equal(calls.at(-1), "ROLLBACK");
   assert.ok(!calls.some((c) => c.startsWith("INSERT")));
+});
+
+test("pinned pg enables certificate-verified TLS from the Argo environment", () => {
+  // Separate process avoids changing other tests' connection environment.
+  const ssl = JSON.parse(
+    execFileSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        'import pg from "pg"; console.log(JSON.stringify(new pg.Client().ssl));',
+      ],
+      { env: { ...process.env, PGSSLMODE: "verify-full" }, encoding: "utf8" },
+    ),
+  );
+  assert.equal(ssl, true); // Node TLS verifies certificates by default; no rejectUnauthorized:false.
 });

--- a/site/tests/data.test.mjs
+++ b/site/tests/data.test.mjs
@@ -7,6 +7,7 @@ import {
   runData,
   historyDir,
   seconds,
+  recordedTiming,
 } from "../src/lib/results.mjs";
 const current = runData("2026-09-05T193245");
 
@@ -33,4 +34,12 @@ test("old snapshots never borrow current metadata or invented target identities"
   for (const run of runs) assert.doesNotThrow(() => runData(run.id));
   assert.throws(() => runData("../latest"));
   assert.throws(() => seconds("NaNs"));
+});
+
+test("missing historical extremes stay unknown while recorded times retain units", () => {
+  for (const value of [undefined, null, ""])
+    assert.equal(recordedTiming(value), "Not recorded");
+  assert.equal(recordedTiming("0.125s"), "125.00 ms");
+  assert.equal(recordedTiming(1.5), "1.500 s");
+  assert.throws(() => recordedTiming("NaNs"), /Invalid timing/);
 });


### PR DESCRIPTION
Weekly scheduling now rejects checkpoint source values such as `HEAD`, branch names, missing values and abbreviated hashes instead of resolving a moving ref and potentially skipping a needed full run. Historical result pages display “Not recorded” for missing Min/Max fields, and `.vercelignore` changes trigger website CI.

This addresses three late findings on PR326. The TLS finding’s premise does not hold for pinned pg 8.16.3: its connection-parameters implementation reads PGSSLMODE and maps verify-full to SSL enabled. A subprocess regression test confirms that behavior; the deployed Argo template supplies verify-full and the trusted CA through NODE_EXTRA_CA_CERTS. TLS behavior is unchanged. Architecture docs now describe the deployed Astro/Git/Postgres relationship.

Validation: 148 Python tests, five site/archive tests, four desktop/mobile browser tests against a fresh local preview, 191-page build and focused Ruff. Historical artifact bytes are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Results pages now display recorded minimum and maximum timings consistently, including a clear “Not recorded” message when timing data is unavailable.
  * Checkpoint planning now rejects mutable or invalid source revisions before processing.

* **Documentation**
  * Updated pipeline documentation to reflect the live Astro report, archived snapshots, and completed database indexing.
  * Revised architecture diagrams to show the published snapshot flow through reporting and archival systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->