### PR TITLE
Handle missing run-clock scope during publication

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -53,7 +53,7 @@ reviews:
       instructions: |
         Python scripts for analysis and publishing.
         Review for:
-        - Consistent chart styling (Tokyo Night theme)
+        - Consistent chart styling (the current cream/forest report palette; historical images retain their original theme)
         - Correct data handling from benchmark JSON files
 
     - path: ".github/workflows/**"

--- a/dagger-poc/test_report_metadata.py
+++ b/dagger-poc/test_report_metadata.py
@@ -50,3 +50,28 @@ def test_rejects_incomplete_foreign_or_invalid_clocks(field, value):
     record[field] = value
     with pytest.raises(ValueError):
         module.execution_metadata(record, rows)
+
+
+@pytest.mark.parametrize("elapsed", [None, 0, 98.4])
+@pytest.mark.parametrize("scope", [None, "", "Includes setup and measurement."])
+def test_readme_publication_accepts_nullable_clock_scope(tmp_path, elapsed, scope):
+    publisher_spec = importlib.util.spec_from_file_location(
+        "publish", Path(__file__).parents[1] / "publish.py"
+    )
+    publisher = importlib.util.module_from_spec(publisher_spec)
+    publisher_spec.loader.exec_module(publisher)
+    readme = tmp_path / "README.md"
+    readme.write_text("Intro\n<!-- latest-run:start -->old<!-- latest-run:end -->\nEnd")
+    publisher.update_readme(readme, "example", 75, {"execution": {
+        "elapsed_seconds": elapsed, "elapsed_scope": scope,
+    }})
+    result = readme.read_text()
+    assert result.startswith("Intro\n") and result.endswith("\nEnd")
+    assert "75 implementations" in result
+    expected_scope = scope or (
+        "Whole-run time was not recorded" if elapsed is None
+        else "Run-clock scope was not recorded."
+    )
+    assert expected_scope in result
+    if elapsed == 0:
+        assert "0h 0m 0s" in result

--- a/publish.py
+++ b/publish.py
@@ -26,10 +26,10 @@ def update_readme(readme: Path, run_id: str, count: int, metadata: dict) -> None
         f"**Latest full run: {duration} · {count} implementations.**\n\n"
         f"[Inspect the run](https://speed-comparison.vercel.app/runs/{run_id}/) · "
         "[Download the image](https://speed-comparison.vercel.app/report-images/latest.png)\n\n"
-        + clock.get(
-            "elapsed_scope",
-            "Whole-run time was not recorded; individual sample times are not a workflow clock.",
-        )
+        + (clock.get("elapsed_scope") or (
+            "Whole-run time was not recorded; individual sample times are not a workflow clock."
+            if elapsed is None else "Run-clock scope was not recorded."
+        ))
         + "\n<!-- latest-run:end -->"
     )
     readme.write_text(


### PR DESCRIPTION
Publication previously crashed when a valid run clock had `elapsed_scope: null`. Treat an empty or missing scope as unknown, preserving the recorded duration and providing the appropriate explanatory note.

Adds nine regression cases for missing/empty/recorded scope with absent, zero and positive elapsed times. Updates the review configuration's obsolete Tokyo Night requirement to describe the current report palette, preserving historical images.

Validation: all 166 pipeline tests passed; the report rendering and local publication smoke check passed. Addresses both late review comments on #328.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved README timing messages when elapsed time or run-clock scope is unavailable.
  - Clarified fallback messaging for recorded durations with missing clock-scope details.
  - Preserved accurate zero-duration and nullable timing displays.

- **Tests**
  - Added coverage for README publication scenarios involving missing elapsed times, zero-duration runs, and clock-scope fallbacks.

- **Documentation**
  - Updated Python review guidance to use the current cream-and-forest report palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->